### PR TITLE
Added all Locations and NPCs in Skyblock

### DIFF
--- a/src/main/java/codes/biscuit/skyblockaddons/mixins/MixinGuiChest.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/mixins/MixinGuiChest.java
@@ -199,7 +199,7 @@ public abstract class MixinGuiChest extends GuiContainer {
             }
         }
         if (main.getConfigValues().isEnabled(Feature.STOP_DROPPING_SELLING_RARE_ITEMS) &&
-                lowerChestInventory.hasCustomName() && EnumUtils.Merchant.isMerchant(lowerChestInventory.getDisplayName().getUnformattedText())
+                lowerChestInventory.hasCustomName() && EnumUtils.SkyblockNPC.isMerchant(lowerChestInventory.getDisplayName().getUnformattedText())
                 && slotIn != null && slotIn.inventory instanceof InventoryPlayer) {
             if (main.getInventoryUtils().shouldCancelDrop(slotIn)) return;
         }

--- a/src/main/java/codes/biscuit/skyblockaddons/utils/EnumUtils.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/utils/EnumUtils.java
@@ -159,13 +159,52 @@ public class EnumUtils {
 
     public enum Location {
         ISLAND("Your Island"),
-        BLAZING_FORTRESS("Blazing Fortress"),
+        // Hub
         VILLAGE("Village"),
-        WILDERNESS("Wilderness"),
+        AUCTION_HOUSE("Auction House"),
         BANK("Bank"),
+        LIBRARY("Library"),
+        COAL_MINE("Coal Mine"),
+        GRAVEYARD("Graveyard"),
+        COLOSSEUM("Colosseum"),
+        WILDERNESS("Wilderness"),
+        MOUNTAIN("Mountain"),
+        WIZARD_TOWER("Wizard Tower"),
+        RUINS("Ruins"),
+        FOREST("Forest"),
+        FARM("Farm"),
+        FISHERMANS_HUT("Fisherman's Hut"),
+        HIGH_LEVEL("High Level"),
+        FLOWER_HOUSE("Flower House"),
+        CANVAS_ROOM("Canvas Room"),
+        TAVERN("Tavern"),
+        // Floating Islands
+        BIRCH_PARK("Birch Park"),
+        SPRUCE_WOODS("Spruce Woods"),
+        JUNGLE_ISLAND("Jungle Island"),
+        SAVANNA_WOODLAND("Savanna Woodland"),
+        DARK_THICKET("Dark Thicket"),
+        // Gold Mine
+        GOLD_MINE("Gold Mine"),
+        // Deep Caverns
+        DEEP_CAVERNS("Deep Caverns"),
+        GUNPOWDER_MINES("Gunpowder Mines"),
+        LAPIS_QUARRY("Lapis Quarry"),
+        PIGMAN_DEN("Pigmen's Den"),
+        SLIMEHILL("Slimehill"),
+        DIAMOND_RESERVE("Diamond Reserve"),
+        OBSIDIAN_SANCTUARY("Obsidian Sanctuary"),
+        // The Barn
+        THE_BARN("The Barn"),
+        // Mushroom Desert
+        MUSHROOM_DESERT("Mushroom Desert"),
+        //Spider Den
+        SPIDERS_DEN("Spider's Den"),
+        // Blazing fortress
+        BLAZING_FORTRESS("Blazing Fortress"),
+        // End
         THE_END("The End"),
-        DRAGONS_NEST("Dragon's Nest"),
-        AUCTION_HOUSE("Auction House");
+        DRAGONS_NEST("Dragon's Nest");
 
         private String scoreboardName;
 
@@ -219,48 +258,83 @@ public class EnumUtils {
     }
 
     public enum SkyblockNPC {
-        AUCTION_MASTER(17.5,71,-78.5, Location.VILLAGE, Location.AUCTION_HOUSE),
-        BANKER(20.5,71,-40.5, Location.VILLAGE, Location.BANK),
-        BAKER(34.5, 71, -44.5, Location.VILLAGE),
-        LOBBY_SELECTOR(-9,70,-79, Location.VILLAGE),
-        SIRIUS(91.5,75,176.5, Location.WILDERNESS);
+        AUCTION_MASTER(17.5,71,-78.5, false, Location.VILLAGE, Location.AUCTION_HOUSE),
+        BANKER(20.5,71,-40.5, false, Location.VILLAGE, Location.BANK),
+        BAKER(34.5, 71, -44.5, false, Location.VILLAGE),
+        LOBBY_SELECTOR(-9,70,-79, false, Location.VILLAGE),
+        LUMBER_MERCHANT(-18.5,70,-90, true, Location.VILLAGE),
+        ADVENTURER(-18.5,70,-77, true, Location.VILLAGE),
+        FISH_MERCHANT(-25.5,70,-77, true, Location.VILLAGE),
+        ARMORSMITH(-25.5,70,-90, true, Location.VILLAGE),
+        BLACKSMITH(-19.5,71,-124.5, false, Location.VILLAGE),
+        BLACKSMITH_2(-39.5,77,-299.5, false, Location.GOLD_MINE),
+        FARM_MERCHANT(-7,70,-48.5, true, Location.VILLAGE),
+        MINE_MERCHANT(-19,70,-48.5, true, Location.VILLAGE),
+        WEAPONSMITH(-19,70,-41.5, false, Location.VILLAGE),
+        BUILDER(-7,70,-41.5, true, Location.VILLAGE),
+        LIBRARIAN(17.5,71,-16.5, true, Location.VILLAGE, Location.LIBRARY),
+        MARCO(9.5,71,-14, false, Location.VILLAGE, Location.FLOWER_HOUSE),
+        ALCHEMIST(-33.5,73,-14.5, true, Location.VILLAGE),
+        PAT(-129.5,73,-98.5, true, Location.GRAVEYARD),
+        EVENT_MASTER(-61.5,71,-54.5, false, Location.COLOSSEUM, Location.VILLAGE),
+        GOLD_FORGER(-27.5,74,-294.5, true, Location.GOLD_MINE),
+        IRON_FORGER(-1.5,75,-307.5, false, Location.GOLD_MINE),
+        RUSTY(-20,78,-325.5, false, Location.GOLD_MINE),
+        MADDOX_THE_SLAYER(-87,66,-70, false, Location.VILLAGE, Location.TAVERN),
+        SIRIUS(91.5,75,176.5, false, Location.WILDERNESS);
 
-        private AxisAlignedBB hideArea;
+        private final int hideRadius = 4;
+        private final AxisAlignedBB hideArea;
         private double x;
         private double y;
         private double z;
+        private boolean isMerchant;
         Set<Location> locations;
 
-        SkyblockNPC(double x, double y, double z, Location... locations) {
+        SkyblockNPC(double x, double y, double z, boolean isMerchant, Location... locations) {
             this.x = x;
             this.y = y;
             this.z = z;
-            hideArea = new AxisAlignedBB(x-3, y-3, z-3, x+3, y+3, z+3);
+            this.isMerchant = isMerchant;
+            this.hideArea = new AxisAlignedBB(x - hideRadius, y - hideRadius, z - hideRadius, x + hideRadius, y + hideRadius, z + hideRadius);
             this.locations = EnumSet.copyOf(Arrays.asList(locations));
         }
 
-//        public static boolean isNPC(double x, double y, double z) {
-//            for (SkyblockNPC npc : values()) {
-//                if (npc.x == x && npc.y == y && npc.z == z) {
-//                    return true;
-//                }
-//            }
-//            return false;
-//        }
+        public boolean isAtLocation(Location location) {
+            return this.locations.contains(location);
+        }
 
-        public static boolean isNearNPC(Entity e) {
+        public boolean isNearEntity(Entity entity) {
             Utils utils = SkyblockAddons.getInstance().getUtils();
+            if (this.locations.contains(utils.getLocation())) {
+                double x = entity.posX;
+                double y = entity.posY;
+                double z = entity.posZ;
+
+                return this.hideArea.isVecInside(new Vec3(x, y, z)) && (this.x != x || this.y != y || this.z != z) && utils.isNotNPC(entity);
+            }
+            return false;
+        }
+
+        public static boolean isNearNPC(Entity entity) {
             for (SkyblockNPC npc : values()) {
-                if (npc.locations.contains(utils.getLocation())) {
-                    double x = e.posX; double y = e.posY; double z = e.posZ;
-                    if (npc.hideArea.isVecInside(new Vec3(x, y,z)) &&
-                            (npc.x != x || npc.y != y || npc.z != z) && utils.isNotNPC(e)) {
+                if (npc.isNearEntity(entity))
+                    return true;
+            }
+            return false;
+        }
+
+        public static boolean isMerchant(String name) {// inventory
+            for (SkyblockNPC npc : values()) {
+                if (npc.isMerchant) {
+                    if (name.replaceAll(" ", "_").equalsIgnoreCase(npc.name())) {
                         return true;
                     }
                 }
             }
-            return false;
+            return name.contains("Merchant");
         }
+
     }
 
     public enum SkyblockAddonsGuiTab {
@@ -277,31 +351,6 @@ public class EnumUtils {
         SHOW_ONLY_WHEN_HOLDING_SHIFT,
         MAKE_INVENTORY_COLORED,
         CHANGE_BAR_COLOR_WITH_POTIONS
-    }
-
-    public enum Merchant {
-
-        ADVENTURER("Adventurer"),
-        BUILDER("Builder"),
-        WEAPONSMITH("Weaponsmith"),
-        ARMORSMITH("Armorsmith"),
-        GOLD_FORGER("Gold Forger"),
-        IRON_FORGER("Iron Forger");
-
-        private String name;
-
-        Merchant(String name) {
-            this.name = name;
-        }
-
-        public static boolean isMerchant(String name) {
-            for (Merchant merchant : values()) {
-                if (name.equals(merchant.name)) {
-                    return true;
-                }
-            }
-            return name.contains("Merchant");
-        }
     }
 
     @SuppressWarnings("deprecation")

--- a/src/main/java/codes/biscuit/skyblockaddons/utils/EnumUtils.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/utils/EnumUtils.java
@@ -279,7 +279,7 @@ public class EnumUtils {
         EVENT_MASTER(-61.5,71,-54.5, false, Location.COLOSSEUM, Location.VILLAGE),
         GOLD_FORGER(-27.5,74,-294.5, true, Location.GOLD_MINE),
         IRON_FORGER(-1.5,75,-307.5, false, Location.GOLD_MINE),
-        RUSTY(-20,78,-325.5, false, Location.GOLD_MINE),
+        RUSTY(-20,78,-326, false, Location.GOLD_MINE),
         MADDOX_THE_SLAYER(-87,66,-70, false, Location.VILLAGE, Location.TAVERN),
         SIRIUS(91.5,75,176.5, false, Location.WILDERNESS);
 


### PR DESCRIPTION
Author: GoldenDusk

All Locations are now in the Location enum.
Plugin now hides players at all NPCs in Skyblock.
Merchant merged into SkyblockNPC. isMerchant moved to SkyblockNPC for merchant-only features.