### PR TITLE
Fix the fps drop in the latest update.

### DIFF
--- a/src/main/java/codes/biscuit/skyblockaddons/listeners/RenderListener.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/listeners/RenderListener.java
@@ -243,7 +243,7 @@ public class RenderListener {
     public void drawBar(Feature feature, float scale, Minecraft mc, ButtonLocation buttonLocation) {
         mc.getTextureManager().bindTexture(BARS);
 
-        if (main.getUtils().isUsingOldSkyblockPackTexture(BARS)) {
+        if (main.getUtils().usingOldSkyBlockTexture) {
             mc.getTextureManager().bindTexture(IMPERIAL_BARS_FIX);
         }
 

--- a/src/main/java/codes/biscuit/skyblockaddons/mixins/MixinMinecraft.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/mixins/MixinMinecraft.java
@@ -1,0 +1,49 @@
+package codes.biscuit.skyblockaddons.mixins;
+
+import codes.biscuit.skyblockaddons.SkyblockAddons;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.resources.IReloadableResourceManager;
+import net.minecraft.client.resources.IResource;
+import net.minecraft.util.ResourceLocation;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+@Mixin(Minecraft.class)
+public class MixinMinecraft {
+    private final ResourceLocation currentLocation = new ResourceLocation("skyblockaddons", "bars.png");
+    private final String oldPath = "assets/skyblockaddons/imperialoldbars.png";
+
+    @Shadow
+    private IReloadableResourceManager mcResourceManager;
+
+    @Inject(method = "refreshResources", at = @At("RETURN"))
+    private void onRefreshResources(CallbackInfo cb) {
+        boolean usingOldTexture = false;
+
+        try {
+            IResource currentResource = mcResourceManager.getResource(currentLocation);
+            InputStream oldStream = SkyblockAddons.class.getClassLoader().getResourceAsStream(oldPath);
+            if (oldStream != null) {
+                String currentHash = DigestUtils.md5Hex(currentResource.getInputStream());
+                String oldHash = DigestUtils.md5Hex(oldStream);
+
+                usingOldTexture = currentHash.equals(oldHash);
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        SkyblockAddons sba = SkyblockAddons.getInstance();
+        // Minecraft reloads textures before and after mods are loaded. So only set the variable if sba was initialized
+        if (sba != null) {
+            sba.getUtils().usingOldSkyBlockTexture = usingOldTexture;
+        }
+    }
+}

--- a/src/main/java/codes/biscuit/skyblockaddons/utils/Utils.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/utils/Utils.java
@@ -60,6 +60,8 @@ public class Utils {
     // I know this is messy af, but frustration led me to take this dark path
     public static boolean blockNextClick = false;
 
+    public boolean usingOldSkyBlockTexture = false;
+
     private final Pattern STRIP_COLOR_PATTERN = Pattern.compile("(?i)§[0-9A-FK-OR]");
     private final Pattern ITEM_COOLDOWN_PATTERN = Pattern.compile("§5§o§8Cooldown: §a([0-9]+)s");
     private final Pattern ALTERNATE_COOLDOWN_PATTERN = Pattern.compile("§5§o§8([0-9]+) Second Cooldown");
@@ -789,34 +791,6 @@ public class Utils {
 
     public boolean isPickaxe(Item item) {
         return Items.wooden_pickaxe.equals(item) || Items.stone_pickaxe.equals(item) || Items.golden_pickaxe.equals(item) || Items.iron_pickaxe.equals(item) || Items.diamond_pickaxe.equals(item);
-    }
-
-    public boolean isUsingOldSkyblockPackTexture(ResourceLocation resourceLocation) {
-        try {
-            Minecraft mc = Minecraft.getMinecraft();
-            IResource resource = mc.getResourceManager().getResource(resourceLocation);
-            BufferedImage targetImage = TextureUtil.readBufferedImage(resource.getInputStream());
-            DataBuffer targetData = targetImage.getData().getDataBuffer();
-            int sizeA = targetData.getSize();
-
-            BufferedImage originalImage = TextureUtil.readBufferedImage(getClass().getClassLoader().getResourceAsStream("assets/skyblockaddons/imperialoldbars.png"));
-            DataBuffer originalData = originalImage.getData().getDataBuffer();
-            int sizeB = originalData.getSize();
-            // compare data-buffer objects //
-            if (sizeA == sizeB) {
-                for(int i=0; i<sizeA; i++) {
-                    if(targetData.getElem(i) != originalData.getElem(i)) {
-                        return false;
-                    }
-                }
-                return true;
-            } else {
-                return false;
-            }
-        } catch (IOException | NullPointerException e) {
-            e.printStackTrace();
-        }
-        return false;
     }
 
     private boolean lookedOnline = false;

--- a/src/main/resources/mixins.skyblockaddons.json
+++ b/src/main/resources/mixins.skyblockaddons.json
@@ -19,6 +19,7 @@
     "MixinRendererLivingEntity",
     "MixinItem",
     "MixinGuiNewChat",
-    "MixinEntityLayerCustomHead"
+    "MixinEntityLayerCustomHead",
+    "MixinMinecraft"
   ]
 }


### PR DESCRIPTION
Moved the old texture check to run only when the textures are reloaded rather than every frame (or twice per frame if you had both bars enabled). I also switched it to a hash comparison because it was about 2 ms faster in my testing and it's a bit cleaner.

closes #204 