### PR TITLE
Add minVersion to Mixin config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
         maven {
             name = "forge"
-            url = "http://files.minecraftforge.net/maven"
+            url = "https://files.minecraftforge.net/maven"
         }
         maven {
             name = "sponge"
@@ -43,7 +43,7 @@ repositories {
     mavenCentral()
     maven {
         name = 'sponge'
-        url = 'http://repo.spongepowered.org/maven'
+        url = 'https://repo.spongepowered.org/maven'
     }
 }
 

--- a/src/main/resources/mixins.skyblockaddons.json
+++ b/src/main/resources/mixins.skyblockaddons.json
@@ -2,6 +2,7 @@
   "package": "codes.biscuit.skyblockaddons.mixins",
   "refmap": "mixins.skyblockaddons.refmap.json",
   "compatibilityLevel": "JAVA_8",
+  "minVersion": "0.6.4",
   "verbose": true,
   "mixins": [
     "MixinEntityPlayerSP",


### PR DESCRIPTION
With the release of Mixin 0.8, and a lot of feature changes, I think it is much safer to lock the version. 

I’m not aware of any mods that bundle Mixin in, so in the future it may be better to lock the version to require 0.8 for the latest improvements. 