### PR TITLE
Fix a crash while trying to hide minion location warning

### DIFF
--- a/src/main/java/codes/biscuit/skyblockaddons/listeners/RenderListener.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/listeners/RenderListener.java
@@ -112,7 +112,7 @@ public class RenderListener {
             }
             if (entity.getCustomNameTag().startsWith("§c/!\\")) {
                 for (Entity listEntity : Minecraft.getMinecraft().theWorld.loadedEntityList) {
-                    if (listEntity.getCustomNameTag().startsWith("§cThis location isn\'t perfect! :(") &&
+                    if (listEntity.getCustomNameTag() != null && listEntity.getCustomNameTag().startsWith("§cThis location isn\'t perfect! :(") &&
                             listEntity.posX == entity.posX && listEntity.posZ == entity.posZ &&
                             listEntity.posY + 0.375 == entity.posY) {
                         e.setCanceled(true);


### PR DESCRIPTION
Added a check if an entity actually has a custom name tag, since minecarts (and probably some other entities too) don't have one, thus crashing the game with a Null Pointer Exception.