### PR TITLE
Fix drop prevention & slot locking failing during server change

### DIFF
--- a/src/main/java/codes/biscuit/skyblockaddons/asm/hooks/EntityPlayerSPHook.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/asm/hooks/EntityPlayerSPHook.java
@@ -20,7 +20,7 @@ public class EntityPlayerSPHook {
         SkyblockAddons main = SkyblockAddons.getInstance();
         Minecraft mc = Minecraft.getMinecraft();
         ItemStack heldItemStack = mc.thePlayer.getHeldItem();
-        if (main.getConfigValues().isEnabled(Feature.LOCK_SLOTS) && main.getUtils().isOnSkyblock()) {
+        if (main.getConfigValues().isEnabled(Feature.LOCK_SLOTS) && (main.getUtils().isOnSkyblock() || main.getPlayerListener().aboutToChangeWorld() || !main.getPlayerListener().didntRecentlyJoinWorld())) {
             int slot = mc.thePlayer.inventory.currentItem + 36;
             if (main.getConfigValues().getLockedSlots().contains(slot)
                     && (slot >= 9 || mc.thePlayer.openContainer instanceof ContainerPlayer && slot >= 5)) {
@@ -33,7 +33,7 @@ public class EntityPlayerSPHook {
         }
         if (heldItemStack != null) {
             EnumUtils.Rarity rarity = EnumUtils.Rarity.getRarity(heldItemStack);
-            if (rarity != null && main.getUtils().isOnSkyblock() && main.getConfigValues().isEnabled(Feature.STOP_DROPPING_SELLING_RARE_ITEMS) &&
+            if (rarity != null && (main.getUtils().isOnSkyblock() || main.getPlayerListener().aboutToChangeWorld() || !main.getPlayerListener().didntRecentlyJoinWorld()) && main.getConfigValues().isEnabled(Feature.STOP_DROPPING_SELLING_RARE_ITEMS) &&
                     main.getUtils().cantDropItem(heldItemStack, rarity, true)) {
                 SkyblockAddons.getInstance().getUtils().sendMessage(main.getConfigValues().getColor(Feature.STOP_DROPPING_SELLING_RARE_ITEMS)
                                                                             + Message.MESSAGE_CANCELLED_DROPPING.getMessage());

--- a/src/main/java/codes/biscuit/skyblockaddons/asm/hooks/EntityPlayerSPHook.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/asm/hooks/EntityPlayerSPHook.java
@@ -20,7 +20,7 @@ public class EntityPlayerSPHook {
         SkyblockAddons main = SkyblockAddons.getInstance();
         Minecraft mc = Minecraft.getMinecraft();
         ItemStack heldItemStack = mc.thePlayer.getHeldItem();
-        if (main.getConfigValues().isEnabled(Feature.LOCK_SLOTS) && (main.getUtils().isOnSkyblock() || main.getPlayerListener().aboutToChangeWorld() || !main.getPlayerListener().didntRecentlyJoinWorld())) {
+        if (main.getConfigValues().isEnabled(Feature.LOCK_SLOTS) && (main.getUtils().isOnSkyblock() || main.getPlayerListener().aboutToJoinSkyblockServer() || !main.getPlayerListener().didntRecentlyJoinWorld())) {
             int slot = mc.thePlayer.inventory.currentItem + 36;
             if (main.getConfigValues().getLockedSlots().contains(slot)
                     && (slot >= 9 || mc.thePlayer.openContainer instanceof ContainerPlayer && slot >= 5)) {
@@ -33,7 +33,7 @@ public class EntityPlayerSPHook {
         }
         if (heldItemStack != null) {
             EnumUtils.Rarity rarity = EnumUtils.Rarity.getRarity(heldItemStack);
-            if (rarity != null && (main.getUtils().isOnSkyblock() || main.getPlayerListener().aboutToChangeWorld() || !main.getPlayerListener().didntRecentlyJoinWorld()) && main.getConfigValues().isEnabled(Feature.STOP_DROPPING_SELLING_RARE_ITEMS) &&
+            if (rarity != null && (main.getUtils().isOnSkyblock() || main.getPlayerListener().aboutToJoinSkyblockServer() || !main.getPlayerListener().didntRecentlyJoinWorld()) && main.getConfigValues().isEnabled(Feature.STOP_DROPPING_SELLING_RARE_ITEMS) &&
                     main.getUtils().cantDropItem(heldItemStack, rarity, true)) {
                 SkyblockAddons.getInstance().getUtils().sendMessage(main.getConfigValues().getColor(Feature.STOP_DROPPING_SELLING_RARE_ITEMS)
                                                                             + Message.MESSAGE_CANCELLED_DROPPING.getMessage());

--- a/src/main/java/codes/biscuit/skyblockaddons/listeners/PlayerListener.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/listeners/PlayerListener.java
@@ -74,6 +74,7 @@ public class PlayerListener {
     private long lastClosedInv = -1;
     private long lastFishingAlert = 0;
     private long lastBobberEnteredWater = Long.MAX_VALUE;
+    private long lastServerChangeAttempt = Long.MAX_VALUE;
 
     private boolean oldBobberIsInWater = false;
     private double oldBobberPosY = 0;
@@ -185,6 +186,10 @@ public class PlayerListener {
                     main.getRenderListener().setArrowsLeft(arrowsLeft);// THIS IS IMPORTANT
                     main.getScheduler().schedule(Scheduler.CommandType.RESET_SUBTITLE_FEATURE, main.getConfigValues().getWarningSeconds());
                 }
+            }
+
+            if (formattedText.startsWith("§7Sending to server ")){
+                lastServerChangeAttempt = System.currentTimeMillis();
             }
 
             Matcher matcher = ABILITY_CHAT_PATTERN.matcher(e.message.getFormattedText());
@@ -666,6 +671,8 @@ public class PlayerListener {
     public boolean didntRecentlyJoinWorld() {
         return System.currentTimeMillis() - lastWorldJoin > 3000;
     }
+
+    public boolean aboutToChangeWorld() { return System.currentTimeMillis() - lastServerChangeAttempt < 6000; }
 
     Integer getHealthUpdate() {
         return actionBarParser.getHealthUpdate();

--- a/src/main/java/codes/biscuit/skyblockaddons/listeners/PlayerListener.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/listeners/PlayerListener.java
@@ -74,7 +74,7 @@ public class PlayerListener {
     private long lastClosedInv = -1;
     private long lastFishingAlert = 0;
     private long lastBobberEnteredWater = Long.MAX_VALUE;
-    private long lastServerChangeAttempt = Long.MAX_VALUE;
+    private long lastSkyblockServerJoinAttempt = 0;
 
     private boolean oldBobberIsInWater = false;
     private double oldBobberPosY = 0;
@@ -189,7 +189,7 @@ public class PlayerListener {
             }
 
             if (formattedText.startsWith("§7Sending to server ")){
-                lastServerChangeAttempt = System.currentTimeMillis();
+                lastSkyblockServerJoinAttempt = System.currentTimeMillis();
             }
 
             Matcher matcher = ABILITY_CHAT_PATTERN.matcher(e.message.getFormattedText());
@@ -672,7 +672,7 @@ public class PlayerListener {
         return System.currentTimeMillis() - lastWorldJoin > 3000;
     }
 
-    public boolean aboutToChangeWorld() { return System.currentTimeMillis() - lastServerChangeAttempt < 6000; }
+    public boolean aboutToJoinSkyblockServer() { return System.currentTimeMillis() - lastSkyblockServerJoinAttempt < 6000; }
 
     Integer getHealthUpdate() {
         return actionBarParser.getHealthUpdate();


### PR DESCRIPTION
Add additional checks if Utils.isOnSkyblock returns false before/after server change