### PR TITLE
Ensure that the player is in multiplayer before checking if they're on hypixel

### DIFF
--- a/src/main/java/codes/biscuit/skyblockaddons/utils/Utils.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/utils/Utils.java
@@ -153,7 +153,7 @@ public class Utils {
         boolean foundLocation = false;
         Minecraft mc = Minecraft.getMinecraft();
 
-        if (mc != null && mc.theWorld != null && mc.getCurrentServerData().serverIP.contains("hypixel.net")) {
+        if (mc != null && mc.theWorld != null && !mc.isSingleplayer() && mc.getCurrentServerData().serverIP.contains("hypixel.net")) {
             Scoreboard scoreboard = mc.theWorld.getScoreboard();
             ScoreObjective sidebarObjective = mc.theWorld.getScoreboard().getObjectiveInDisplaySlot(1);
             if (sidebarObjective != null) {


### PR DESCRIPTION
This fixes a crash that happens whenever joining a singleplayer world.