### PR TITLE
Bug Fixes: itemDropChecker and Location

### DIFF
--- a/src/main/java/codes/biscuit/skyblockaddons/utils/ItemDropChecker.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/utils/ItemDropChecker.java
@@ -54,7 +54,7 @@ public class ItemDropChecker {
         this.LOGGER = LogManager.getLogger("SBA Item Drop Checker");
 
         // Try to get the lists from the file.
-        String ITEM_DROP_LIST_FILE_PATH = "lists/itemDrop.json";
+        String ITEM_DROP_LIST_FILE_PATH = "lists/itemDropList.json";
         JsonReader jsonFileReader = new JsonReader(new BufferedReader(new InputStreamReader(Objects.requireNonNull(
                 getClass().getClassLoader().getResourceAsStream(ITEM_DROP_LIST_FILE_PATH),
                 "Item drop list not found!"))));

--- a/src/main/java/codes/biscuit/skyblockaddons/utils/Utils.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/utils/Utils.java
@@ -92,7 +92,7 @@ public class Utils {
     private boolean onSkyblock = false;
 
     /** The player's current location in Skyblock */
-    private Location location = null;
+    private Location location = Location.UNKNOWN;
 
     /** The skyblock profile that the player is currently on. Ex. "Grapefruit" */
     private String profileName = null;
@@ -272,7 +272,7 @@ public class Utils {
             }
         }
         if (!foundLocation) {
-            location = null;
+            location = Location.UNKNOWN;
         }
         if (!foundJerryWave) {
             jerryWave = -1;


### PR DESCRIPTION
This PR fixes:
- itemDropChecker opening the wrong file since it's named `lists/itemDropChecker.json` not `lists/itemDrop.json` 
- Discord Rich Presence module raising a NullPointerException and crashing the game since the default location was set to `null` instead of `Location.UNKNOWN`.

Feel free to correct me if I did something wrong or broke a thing.