### PR TITLE
Fix github actions build.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - '**'
-    tags-ignore:
-      # Beta has it's own workflow.
-      - Beta
   pull_request:
   
 jobs:
@@ -24,8 +21,6 @@ jobs:
         java-version: 1.8
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
-    - name: LS
-      run: ls
     - name: Setup ForgeGradle
       run: ./gradlew setupCIWorkspace
     - name: Read mod name
@@ -50,8 +45,8 @@ jobs:
       run: ./gradlew build
     - name: Upload mod jar
       env:
-        mod_jar_name: ${{ steps.read_mod_name.outputs.value }}-${{ steps.read_mod_version.outputs.value }}-for-MC-1.8.9
-        mod_jar_path: build/libs/${{ steps.read_mod_name.outputs.value }}-${{ steps.read_mod_version.outputs.value }}-for-MC-1.8.9.jar
+        mod_jar_name: ${{ steps.read_mod_name.outputs.value }}-${{ steps.read_mod_version.outputs.value }}-for-MC-${{ steps.read_mc_version.outputs.value }}
+        mod_jar_path: build/libs/${{ steps.read_mod_name.outputs.value }}-${{ steps.read_mod_version.outputs.value }}-for-MC-${{ steps.read_mc_version.outputs.value }}.jar
       uses: actions/upload-artifact@v1.0.0
       with:
         name: ${{ env.mod_jar_name }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,8 +50,8 @@ jobs:
       run: ./gradlew build
     - name: Upload mod jar
       env:
-        mod_jar_name: ${{ steps.read_mod_name.outputs.value }}-${{ steps.read_mc_version.outputs.value }}-${{ steps.read_mod_version.outputs.value }}
-        mod_jar_path: build/libs/${{ steps.read_mod_name.outputs.value }}-${{ steps.read_mc_version.outputs.value }}-${{ steps.read_mod_version.outputs.value }}.jar
+        mod_jar_name: ${{ steps.read_mod_name.outputs.value }}-${{ steps.read_mod_version.outputs.value }}-for-MC-1.8.9
+        mod_jar_path: build/libs/${{ steps.read_mod_name.outputs.value }}-${{ steps.read_mod_version.outputs.value }}-for-MC-1.8.9.jar
       uses: actions/upload-artifact@v1.0.0
       with:
         name: ${{ env.mod_jar_name }}


### PR DESCRIPTION
Fix the GitHub actions build. The issue was you didn't update the name of the build jar in the build file. I hardcoded the `-for-MC-1.8.9` since its the same in the build.gradle. Remember to update this next time you change the file name in build.gradle.