### PR TITLE
Rewrite Assembly Transformers

### DIFF
--- a/asm-api/build.gradle
+++ b/asm-api/build.gradle
@@ -1,0 +1,4 @@
+dependencies {
+    implementation('org.ow2.asm:asm:9.0-beta')
+    implementation('org.ow2.asm:asm-tree:9.0-beta')
+}

--- a/asm-api/src/main/java/codes/biscuit/skyblockaddons/asm/api/TransformerEngine.java
+++ b/asm-api/src/main/java/codes/biscuit/skyblockaddons/asm/api/TransformerEngine.java
@@ -1,0 +1,21 @@
+package codes.biscuit.skyblockaddons.asm.api;
+
+import org.objectweb.asm.tree.ClassNode;
+
+/**
+ * Manage the transformers and transform any class node.
+ *
+ * @author iHDeveloper
+ */
+public abstract class TransformerEngine {
+
+    /**
+     * Transform the class node through the transformers
+     *
+     * @param node The class to transform
+     */
+    public void transform(ClassNode node) {
+        throw new UnsupportedOperationException();
+    }
+
+}

--- a/build.gradle
+++ b/build.gradle
@@ -10,31 +10,37 @@ group = 'codes.biscuit'
 // The below line is for version checkers <= 1.4.2
 //version = "1.5.2"
 
-// Java plugin settings
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-compileJava.options.encoding = 'UTF-8'
+allprojects {
+    apply plugin: 'java'
 
-repositories {
-    mavenCentral()
-    maven {
-        name 'JitPack'
-        url 'https://jitpack.io'
-    }
-}
+    // Java plugin settings
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+    compileJava.options.encoding = 'UTF-8'
 
-dependencies {
-    // Discord RPC for Java https://github.com/jagrosh/DiscordIPC
-    implementation('com.github.jagrosh:DiscordIPC:e29d6d8') {
-        exclude module: 'log4j'
+    repositories {
+        mavenCentral()
+        maven {
+            name 'JitPack'
+            url 'https://jitpack.io'
+        }
     }
-    testImplementation('org.junit.jupiter:junit-jupiter:5.6.2')
 }
 
 sourceSets {
     main {
         output.resourcesDir = java.outputDir
     }
+}
+
+dependencies {
+    // Assembly Transformer API
+    implementation(project('asm-api'))
+    // Discord RPC for Java https://github.com/jagrosh/DiscordIPC
+    implementation('com.github.jagrosh:DiscordIPC:e29d6d8') {
+        exclude module: 'log4j'
+    }
+    testImplementation('org.junit.jupiter:junit-jupiter:5.6.2')
 }
 
 minecraft {

--- a/settings.gradle
+++ b/settings.gradle
@@ -14,3 +14,6 @@ pluginManagement {
         }
     }
 }
+
+// Assembly Transformer API
+include 'asm-api'


### PR DESCRIPTION
# Info
Assembly transformers are a huge part of the **SkyblockAddons**. And, the current architecture of it doesn't provide the flexibility for the mod to support multiple versions of **Minecraft**. Since the mod is going to support `1.12.2`, `1.15.2` (#334 #236 #315)

There are many duplications when writing a transformer. And, it's hard to keep track of it, especially when supporting a new version of the game. 😐

This **PR** provides a new architecture that will solve most of these problems. And, It's very flexible and smooth to work with. And, It will allow us to support multiple versions of **Minecraft**. 😄

Also, this **PR** is part of #337. Since the mod features depend on the assembly transformers.

> **Note:** This PR rewrites a huge part of the Mod. And, it should be dealt with very carefully. In order not to break any features.

# Architecture
![image](https://user-images.githubusercontent.com/20463031/88475112-b976ac00-cf35-11ea-9637-11ff062582c5.png)

## General
The architecture will isolate the assembly transformers from the mod in a standalone module. So, the **mod** can focus on the features while the **assembly transformers** focus on injecting hooks that trigger those features by safely transforming classes.

|Name|Description|
|----|-----|
| **Forge** | It will give us the bytecode of each class |
| **SkyblockAddons** | Parse the bytecode as `Class Node`. Usually, we don't need to change this part in every version we will support. |
| **ASM-API** | Pass the `Class Node` through the transformers to change how it behaves. This part is dynamic since each **Minecraft** version has big changes than the old one. |

## Assembly Transformers
![image](https://user-images.githubusercontent.com/20463031/88475694-05781f80-cf3b-11ea-9083-7b84df425a90.png)
The architecture will break the transformation process into parts explained in the table below. Each part has its task to do. Which will provides us the flexibility that we need in making new features.

|Name|Description|
|----|-----|
| **Assembly API** | An interface for the mod to interact with. Without specifying a version |
| **Engine** | It takes the `Class Node` as input and transforms it through registered transformers. And, register hook for each transformer if required |
| **Transformer** | Inject hooks using **Assembly Helper** to change how certain class or method behaves into triggering those hooks. |
| **Assembly Helper** | Apply a change into the bytecode of class, method, etc... **It's included in the `API` since it's not a dynamic part in the architecture** |
| **Hook** | An easy way to listen to triggered actions by a trigger that was injected by **Transformer** |

> **Note about hooks:** In the architecture I'm assuming that each feature of the mod is cross-version. So, the mod should tell the engine what are the hooks to trigger.
> Basically, the assembly transformer API doesn't hold any hooks for **each version**. Instead of that, the mod will hold them.
>
> Reference: #236

# Getting Started
**`W.I.P`**

# Checklist
**API**
- [x] Create module `ASM-API`
- - [ ] Implement an identifier for class, method, etc...
- - [ ] Provide an interface for the transformer
- - [ ] Implement functionality to the engine
- - [ ] Implement assembly helpers in the API
- - - [ ] Assembly finder
- - - [ ] Assembly inserter
- - - [ ] Assembly replacer
- - - [ ] A helper that connects all of them together
- - [ ] Implement an interface for the hook in the API
- - [ ] Implement each hook in the engine
- - [ ] Implement an interface for each transformer

**Minecraft `1.8.9`**
- [ ] Create module `ASM-V18` for Minecraft 1.8.9
- - [ ] Implementation for each transformer
- - [ ] Implement the engine

**Integrate the mod with the API**
- [ ] Compile `ASM-V18` with `Forge 1.8.9`
- [ ] Transform using `ASM-V18` in `1.8.9`

# Note
This PR is under heavy development. And, anything in this description is subject to change at any time.

This PR was planned before the [multiVersion](https://github.com/BiscuitDevelopment/SkyblockAddons/tree/multiVersion) branch came out. That's why it's based on the `development` branch.

I'm open for any discussion about this PR to see how can we improve it 😃