### PR TITLE
Add traditional Chinese support for the in-Skyblock check

### DIFF
--- a/src/main/java/codes/biscuit/skyblockaddons/utils/Utils.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/utils/Utils.java
@@ -81,8 +81,8 @@ public class Utils {
     private static final Pattern SLAYER_TYPE_REGEX = Pattern.compile("(?<type>Tarantula Broodfather|Revenant Horror|Sven Packmaster) (?<level>[IV]+)");
     private static final Pattern SLAYER_PROGRESS_REGEX = Pattern.compile("(?<progress>[0-9.k]*)/(?<total>[0-9.k]*) (?:Kills|Combat XP)$");
 
-    /** In English, Chinese Simplified. */
-    private static final Set<String> SKYBLOCK_IN_ALL_LANGUAGES = Sets.newHashSet("SKYBLOCK","\u7A7A\u5C9B\u751F\u5B58");
+    /** In English, Chinese Simplified, Traditional Chinese. */
+    private static final Set<String> SKYBLOCK_IN_ALL_LANGUAGES = Sets.newHashSet("SKYBLOCK","\u7A7A\u5C9B\u751F\u5B58", "\u7A7A\u5CF6\u751F\u5B58");
 
     /** Used for web requests. */
     public static final String USER_AGENT = "SkyblockAddons/" + SkyblockAddons.VERSION;


### PR DESCRIPTION
It turns out that traditional Chinese uses a slightly different character in the Sidebar title, thus not enabling SkyblockAddons. 

This PR adds the traditional Chinese Skyblock name to the Set used for the check.