### PR TITLE
Dungeon Fix: Show critical sign to dead teammates

### DIFF
--- a/src/main/java/codes/biscuit/skyblockaddons/core/DungeonPlayer.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/core/DungeonPlayer.java
@@ -83,6 +83,10 @@ public class DungeonPlayer {
         return healthColor == ColorCode.RED;
     }
 
+    public boolean isGhost() {
+        return this.health == 0;
+    }
+
     public void updateStatsFromOther(DungeonPlayer other) {
         this.dungeonClass = other.dungeonClass;
         this.health = other.health;

--- a/src/main/java/codes/biscuit/skyblockaddons/listeners/RenderListener.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/listeners/RenderListener.java
@@ -1766,7 +1766,7 @@ public class RenderListener {
                 }
 
                 DungeonPlayer dungeonPlayer = main.getUtils().getDungeonPlayers().get(entity.getName());
-                if (!dungeonPlayer.isCritical() && !dungeonPlayer.isLow()) {
+                if (dungeonPlayer.isGhost() || (!dungeonPlayer.isCritical() && !dungeonPlayer.isLow())) {
                     continue;
                 }
 


### PR DESCRIPTION
This PR contains a small fix to the dungeon features:
- ~(a23dd3d) Resolve the conflict between action bar and skill display~ (Can be resolved using **GUI Editor**)
- (29889d0) Don't show the critical sign to dead teammates