### PR TITLE
Dungeon Fix: Milestone couldn't detect dungeon class

### DIFF
--- a/src/main/java/codes/biscuit/skyblockaddons/core/DungeonClass.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/core/DungeonClass.java
@@ -12,14 +12,6 @@ public enum DungeonClass {
     MAGE(Items.blaze_rod, "Mage"),
     BERSERKER(Items.iron_sword, "Berserk");
 
-    @Getter private String firstLetter;
-    @Getter private ItemStack item;
-
-    DungeonClass(Item item, String chatDisplayName) {
-        this.firstLetter = this.name().substring(0, 1);
-        this.item = new ItemStack(item);
-    }
-
     public static DungeonClass fromFirstLetter(String firstLetter) {
         for (DungeonClass dungeonClass : DungeonClass.values()) {
             if (dungeonClass.firstLetter.equals(firstLetter)) {
@@ -27,5 +19,24 @@ public enum DungeonClass {
             }
         }
         return null;
+    }
+
+    public static DungeonClass fromDisplayName(String name) {
+        for (DungeonClass dungeonClass : DungeonClass.values()) {
+            if (dungeonClass.getChatDisplayName().equals(name)) {
+                return dungeonClass;
+            }
+        }
+        return null;
+    }
+
+    @Getter private String firstLetter;
+    @Getter private ItemStack item;
+    @Getter private String chatDisplayName;
+
+    DungeonClass(Item item, String chatDisplayName) {
+        this.firstLetter = this.name().substring(0, 1);
+        this.item = new ItemStack(item);
+        this.chatDisplayName = chatDisplayName;
     }
 }

--- a/src/main/java/codes/biscuit/skyblockaddons/utils/DungeonUtils.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/utils/DungeonUtils.java
@@ -46,7 +46,7 @@ public class DungeonUtils {
             return null;
         }
 
-        DungeonClass dungeonClass = DungeonClass.valueOf(matcher.group(1));
+        DungeonClass dungeonClass = DungeonClass.fromDisplayName(matcher.group(1));
         return new DungeonMilestone(dungeonClass, matcher.group(2), matcher.group(3));
 
     }


### PR DESCRIPTION
The milestone was getting the dungeon class using Enum#valueOf
Where it should get it using chat display name