### PR TITLE
Dungeon Fix: Teammate becomes invisible

### DIFF
--- a/src/main/java/codes/biscuit/skyblockaddons/asm/hooks/EntityRendererHook.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/asm/hooks/EntityRendererHook.java
@@ -39,7 +39,7 @@ public class EntityRendererHook {
             list.removeIf(listEntity -> listEntity instanceof EntityItemFrame &&
                     (((EntityItemFrame)listEntity).getDisplayedItem() != null || Minecraft.getMinecraft().thePlayer.getHeldItem() == null));
         }
-        if (main.getConfigValues().isEnabled(Feature.HIDE_PLAYERS_NEAR_NPCS)) {
+        if (!main.getUtils().isInDungeon() && main.getConfigValues().isEnabled(Feature.HIDE_PLAYERS_NEAR_NPCS)) {
             list.removeIf(entity -> entity instanceof EntityOtherPlayerMP && !NPCUtils.isNPC(entity) && NPCUtils.isNearNPC(entity));
         }
     }

--- a/src/main/java/codes/biscuit/skyblockaddons/asm/hooks/RenderManagerHook.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/asm/hooks/RenderManagerHook.java
@@ -33,7 +33,7 @@ public class RenderManagerHook {
                     }
                 }
             }
-            if (main.getConfigValues().isEnabled(Feature.HIDE_PLAYERS_NEAR_NPCS) && mc.theWorld != null) {
+            if (!main.getUtils().isInDungeon() && main.getConfigValues().isEnabled(Feature.HIDE_PLAYERS_NEAR_NPCS) && mc.theWorld != null) {
                 if (entityIn instanceof EntityOtherPlayerMP && !NPCUtils.isNPC(entityIn) && NPCUtils.isNearNPC(entityIn)) {
                     returnValue.cancel();
                 }


### PR DESCRIPTION
Sometimes, the teammate becomes invisible due to the player having the hide NPC feature enabled.
The feature thinks the teammate is close to the NPC. So, the feature hides the teammate from the player

This commit solves the bug by ignoring the feature check. When the player is in a dungeon game

# Screenshot
![image](https://user-images.githubusercontent.com/20463031/90945645-be445800-e42e-11ea-9d8a-91743dec2630.png)
![image](https://user-images.githubusercontent.com/20463031/90945889-83432400-e430-11ea-823a-3c0133dd7ef7.png)
