### PR TITLE
Dungeon Fix: Doesn't detect teammates with symbols

### DIFF
--- a/src/main/java/codes/biscuit/skyblockaddons/core/DungeonPlayer.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/core/DungeonPlayer.java
@@ -13,7 +13,7 @@ import java.util.regex.Pattern;
 
 @Getter @Setter
 public class DungeonPlayer {
-    public static Pattern DUNGEON_PLAYER_LINE = Pattern.compile("^§.\\[(?<class>.)] (?<name>[\\w§]+) §(?<healthColor>.)(?<health>[\\w]+)(?:§c❤)?");
+    public static Pattern DUNGEON_PLAYER_LINE = Pattern.compile("^§.\\[(?<class>.)] (?<name>[\\w§]+) (?:§.)*?§(?<healthColor>.)(?<health>[\\w]+)(?:§c❤)?");
 
     private String name;
     private DungeonClass dungeonClass;

--- a/src/main/java/codes/biscuit/skyblockaddons/utils/TextUtils.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/utils/TextUtils.java
@@ -45,7 +45,7 @@ public class TextUtils {
      * @return Input text with only letters and numbers
      */
     public static String keepScoreboardCharacters(String text) {
-        SCOREBOARD_CHARACTERS = Pattern.compile("[^a-z A-Z:0-9/'.!§\\[\\]❤]");
+        SCOREBOARD_CHARACTERS = Pattern.compile("[^a-z A-Z:0-9_/'.!§\\[\\]❤]");
         return SCOREBOARD_CHARACTERS.matcher(text).replaceAll("");
     }
 


### PR DESCRIPTION
In dungeons, any teammate who has '_' in their name is not included in the map.
That's because the character '_' is being filtered using `TextUtils#keepScoreboardCharacters`

This commit solves the problem by adding `_` to the pattern.

Sometimes, the prefix of the health color has a repeat (e.g. `§a§a`).
This causes the pattern to be broken.

This commit solves the problem by ignoring the repeated part.