### PR TITLE
Fixes #375

### DIFF
--- a/src/main/java/codes/biscuit/skyblockaddons/features/powerorbs/PowerOrbManager.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/features/powerorbs/PowerOrbManager.java
@@ -110,7 +110,7 @@ public class PowerOrbManager {
             return true;
         }
 
-        return powerOrbArmorStand.getCurrentArmor(4) != newPowerOrbArmorStand.getCurrentArmor(4);
+        return powerOrbArmorStand.getEquipmentInSlot(4) != newPowerOrbArmorStand.getEquipmentInSlot(4);
     }
 
     public EntityArmorStand createVirtualArmorStand(EntityArmorStand armorStandToClone) {


### PR DESCRIPTION
The `PowerOrbManager#hasPowerorbEntityChanged` was reading outside the array by using `EntityArmorStand#getCurrentArmor`.
This commit replaces it with `EntityArmorStand#getEquipmentInSlot`.