### PR TITLE
Fixed a typo in string dungeonsMapDisplay

### DIFF
--- a/src/main/resources/lang/en_us.json
+++ b/src/main/resources/lang/en_us.json
@@ -130,7 +130,7 @@
     "changeZealotColor": "Change Zealot Color",
     "hideSvenPupNametags": "Hide Sven Pup Nametags",
     "turnAllFeaturesChroma": "Turn All Features Chroma",
-    "dungeonsMapDisplay": "Dungeons Map Display",
+    "dungeonsMapDisplay": "Dungeon's Map Display",
     "rotateMap": "Rotate Map to Your Player's Rotation",
     "centerRotationOnYourPlayer": "Center the Rotation Around Your Player",
     "mapZoom": "Map Zoom",


### PR DESCRIPTION
It only displays the map of one dungeon at a time so it makes sense to say Dungeon's instead of Dungeons. Another option would be to just say Dungeon.