### PR TITLE
Dungeons: Apply cooldown to Dungeon Orb

### DIFF
--- a/src/main/java/codes/biscuit/skyblockaddons/features/cooldowns/CooldownManager.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/features/cooldowns/CooldownManager.java
@@ -46,6 +46,24 @@ public class CooldownManager {
         }
     }
 
+    /**
+     * Put an item on cooldown by getting the index of which cooldown value from its lore.
+     *
+     * @param item Item to put on cooldown
+     * @param index Index of the cooldown
+     */
+    public static void put(ItemStack item, int index) {
+        if(item == null || !item.hasDisplayName()) {
+            return;
+        }
+
+        int cooldown = getLoreCooldown(item, index);
+        if(cooldown > 0) {
+            // cooldown is returned in seconds and required in milliseconds
+            put(item.getDisplayName(), cooldown * 1000);
+        }
+    }
+
 
     /**
      * Put an item on cooldown with provided cooldown, for items that do not show their cooldown
@@ -151,22 +169,49 @@ public class CooldownManager {
      * @see #ALTERNATE_COOLDOWN_PATTERN
      */
     private static int getLoreCooldown(ItemStack item) {
+        return getLoreCooldown(item, 0);
+    }
+
+    /**
+     * Read multiple cooldown values of an item from it's lore.
+     * And, gets the selected value.
+     * This requires that the lore shows the cooldown either like {@code X Second Cooldown} or
+     * {@code Cooldown: Xs}. Cooldown is returned in seconds.
+     *
+     * @param item Item to read cooldown from
+     * @param index The index of the cooldown
+     * @return Read cooldown in seconds or {@code -1} if no cooldown was found
+     * @see #ITEM_COOLDOWN_PATTERN
+     * @see #ALTERNATE_COOLDOWN_PATTERN
+     */
+    private static int getLoreCooldown(ItemStack item, int index) {
+        int result = -1;
         for (String loreLine : item.getTooltip(Minecraft.getMinecraft().thePlayer, false)) {
             Matcher matcher = ITEM_COOLDOWN_PATTERN.matcher(loreLine);
             if (matcher.matches()) {
                 try {
-                    return Integer.parseInt(matcher.group(1));
+                    result = Integer.parseInt(matcher.group(1));
+
+                    if (index == 0)
+                        break;
+                    else
+                        index--;
                 } catch (NumberFormatException ignored) { }
             } else {
                 matcher = ALTERNATE_COOLDOWN_PATTERN.matcher(loreLine);
                 if (matcher.matches()) {
                     try {
-                        return Integer.parseInt(matcher.group(1));
+                        result = Integer.parseInt(matcher.group(1));
+
+                        if (index == 0)
+                            break;
+                        else
+                            index--;
                     } catch (NumberFormatException ignored) { }
                 }
             }
         }
-        return -1;
+        return result;
     }
 
 }

--- a/src/main/java/codes/biscuit/skyblockaddons/listeners/PlayerListener.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/listeners/PlayerListener.java
@@ -352,6 +352,14 @@ public class PlayerListener {
         ItemStack heldItem = e.entityPlayer.getHeldItem();
 
         if (main.getUtils().isOnSkyblock() && heldItem != null) {
+            // Show cooldown on dungeon orb when the player uses it in dungeons
+            if (main.getConfigValues().isEnabled(Feature.SHOW_ITEM_COOLDOWNS)
+                && main.getUtils().isInDungeon()
+                && (e.action == PlayerInteractEvent.Action.RIGHT_CLICK_BLOCK || e.action == PlayerInteractEvent.Action.RIGHT_CLICK_AIR)
+                && heldItem.getItem().equals(Items.skull)) {
+                main.getDungeonUtils().useOrb(heldItem);
+            }
+
             // Change the GUI background color when a backpack is opened to match the backpack's color.
             if (heldItem.getItem() == Items.skull) {
                 Backpack backpack = BackpackManager.getFromItem(heldItem);

--- a/src/main/java/codes/biscuit/skyblockaddons/utils/DungeonUtils.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/utils/DungeonUtils.java
@@ -4,8 +4,11 @@ import codes.biscuit.skyblockaddons.core.DungeonClass;
 import codes.biscuit.skyblockaddons.core.DungeonMilestone;
 import codes.biscuit.skyblockaddons.core.DungeonPlayer;
 import codes.biscuit.skyblockaddons.core.EssenceType;
+import codes.biscuit.skyblockaddons.features.cooldowns.CooldownManager;
 import lombok.Getter;
 import lombok.Setter;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
 
 import java.util.EnumMap;
 import java.util.HashMap;
@@ -112,5 +115,24 @@ public class DungeonUtils {
 
             collectedEssences.put(essenceType, collectedEssences.getOrDefault(essenceType, 0) + 1);
         }
+    }
+
+    /**
+     * Check if the given item is a dungeon orb. And, notifies the player that it got used.
+     * It applies the cooldown of the second ability. Since the main ability is showed in the experience bar.
+     *
+     * @param orb The dungeon orb item
+     */
+    public void useOrb(ItemStack orb) {
+        NBTTagCompound extraAttributes = orb.getTagCompound().getCompoundTag("ExtraAttributes");
+        if (extraAttributes == null)
+            return;
+        String id = extraAttributes.getString("id");
+        if (id == null)
+            return;
+        if (!id.equals("DUNGEON_STONE"))
+            return;
+
+        CooldownManager.put(orb, 1);
     }
 }


### PR DESCRIPTION
The dungeon orb has multiple cooldown values.
The first cooldown is shown in the experience bar.
The second cooldown is not shown.

This commit puts the second cooldown to the dungeon orb.
- Implement read multiple values in cooldown manager

# Showcases
![image](https://user-images.githubusercontent.com/20463031/92322553-a2e66900-f03a-11ea-957a-e6bb8c99fdd1.png)

![image](https://user-images.githubusercontent.com/20463031/92322545-98c46a80-f03a-11ea-8d49-dab5cbac12bd.png)
