### PR TITLE
Important Fix: Crash during check for the update

### DIFF
--- a/src/main/java/codes/biscuit/skyblockaddons/SkyblockAddons.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/SkyblockAddons.java
@@ -117,8 +117,8 @@ public class SkyblockAddons {
 
     @Mod.EventHandler
     public void postInit(FMLPostInitializationEvent e) {
-        updater.processUpdateCheckResult();
         DataUtils.readLocalAndFetchOnline();
+        updater.processUpdateCheckResult();
         configValues.loadValues();
         persistentValues.loadValues();
 


### PR DESCRIPTION
The updater checks for the new update before fetching online data.
The issue is online data is not loaded using `DataUtils#readLocalAndFetchOnline`.