### PR TITLE
Fix crashes caused by duplicated feature IDs

### DIFF
--- a/src/main/java/codes/biscuit/skyblockaddons/core/Feature.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/core/Feature.java
@@ -180,8 +180,8 @@ public enum Feature {
     DISABLE_BOSS_MESSAGES(148, "settings.disableBossMessages", null, false),
     SHOW_SWORD_KILLS(149, "settings.showSwordKills", new GuiFeatureData(ColorCode.RED, true), false),
 
-    HIDE_OTHER_PLAYERS_PRESENTS(141, "settings.hideOtherPlayersPresents", null,false),
-    EASIER_PRESENT_OPENING(142, "settings.easierPresentOpening", null,false),
+    HIDE_OTHER_PLAYERS_PRESENTS(150, "settings.hideOtherPlayersPresents", null,false),
+    EASIER_PRESENT_OPENING(151, "settings.easierPresentOpening", null,false),
 
     WARNING_TIME(-1, Message.SETTING_WARNING_DURATION, false),
 


### PR DESCRIPTION
Fixed by changing the IDs
The fixes the crash upon start
Full crash logs:

```
Description: There was a severe problem during mod loading that has caused the game to fail
net.minecraftforge.fml.common.LoaderException: java.lang.ExceptionInInitializerError
	at net.minecraftforge.fml.common.LoadController.transition(LoadController.java:162)
	at net.minecraftforge.fml.common.Loader.preinitializeMods(Loader.java:559)
	at net.minecraftforge.fml.client.FMLClientHandler.beginMinecraftLoading(FMLClientHandler.java:243)
	at net.minecraft.client.Minecraft.func_71384_a(Minecraft.java:417)
	at net.minecraft.client.Minecraft.func_99999_d(Minecraft.java:329)
	at net.minecraft.client.main.Main.main(SourceFile:124)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
	at java.lang.reflect.Method.invoke(Unknown Source)
	at net.minecraft.launchwrapper.Launch.launch(Launch.java:135)
	at net.minecraft.launchwrapper.Launch.main(Launch.java:28)
Caused by: java.lang.ExceptionInInitializerError
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
	at java.lang.reflect.Method.invoke(Unknown Source)
	at java.lang.Class.getEnumConstantsShared(Unknown Source)
	at java.lang.System$2.getEnumConstantsShared(Unknown Source)
	at java.util.EnumMap.getKeyUniverse(Unknown Source)
	at java.util.EnumMap.<init>(Unknown Source)
	at codes.biscuit.skyblockaddons.config.ConfigValues.<init>(ConfigValues.java:45)
	at codes.biscuit.skyblockaddons.SkyblockAddons.preInit(SkyblockAddons.java:95)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
	at java.lang.reflect.Method.invoke(Unknown Source)
	at net.minecraftforge.fml.common.FMLModContainer.handleModStateEvent(FMLModContainer.java:560)
	at sun.reflect.GeneratedMethodAccessor4.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
	at java.lang.reflect.Method.invoke(Unknown Source)
	at com.google.common.eventbus.EventSubscriber.handleEvent(EventSubscriber.java:74)
	at com.google.common.eventbus.SynchronizedEventSubscriber.handleEvent(SynchronizedEventSubscriber.java:47)
	at com.google.common.eventbus.EventBus.dispatch(EventBus.java:322)
	at com.google.common.eventbus.EventBus.dispatchQueuedEvents(EventBus.java:304)
	at com.google.common.eventbus.EventBus.post(EventBus.java:275)
	at net.minecraftforge.fml.common.LoadController.sendEventToModContainer(LoadController.java:211)
	at net.minecraftforge.fml.common.LoadController.propogateStateMessage(LoadController.java:189)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
	at java.lang.reflect.Method.invoke(Unknown Source)
	at com.google.common.eventbus.EventSubscriber.handleEvent(EventSubscriber.java:74)
	at com.google.common.eventbus.SynchronizedEventSubscriber.handleEvent(SynchronizedEventSubscriber.java:47)
	at com.google.common.eventbus.EventBus.dispatch(EventBus.java:322)
	at com.google.common.eventbus.EventBus.dispatchQueuedEvents(EventBus.java:304)
	at com.google.common.eventbus.EventBus.post(EventBus.java:275)
	at net.minecraftforge.fml.common.LoadController.distributeStateMessage(LoadController.java:118)
	at net.minecraftforge.fml.common.Loader.preinitializeMods(Loader.java:556)
	... 10 more
Caused by: java.lang.RuntimeException: Multiple features have the same IDs!
	at codes.biscuit.skyblockaddons.core.Feature.<init>(Feature.java:273)
	at codes.biscuit.skyblockaddons.core.Feature.<clinit>(Feature.java:183)
	... 46 more
```