### PR TITLE
[Enhancement] Enhance secrets counter by greying out no secret rooms and showing 0/0

### DIFF
--- a/src/main/java/codes/biscuit/skyblockaddons/listeners/RenderListener.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/listeners/RenderListener.java
@@ -1134,8 +1134,8 @@ public class RenderListener {
             int secrets = main.getDungeonUtils().getSecrets();
             int maxSecrets = main.getDungeonUtils().getMaxSecrets();
             if (secrets == -1) {
-                secrets = 10;
-                maxSecrets = 10;
+                secrets = 0;
+                maxSecrets = 0;
             }
 
             float percent = secrets / (float) maxSecrets;
@@ -1148,7 +1148,12 @@ public class RenderListener {
                 r = (1 - percent) * 0.66F + 0.33F;
                 g = 1;
             }
-            int secretsColor = new Color(r, g, 0.33F).getRGB();
+            int secretsColor;
+            if (maxSecrets == 0) {
+                secretsColor = new Color(170,170,170).getRGB();
+            } else {
+                secretsColor = new Color(r, g, 0.33F).getRGB();
+            }
 
             float secretsWidth = mc.fontRendererObj.getStringWidth(String.valueOf(secrets));
             float slashWidth = mc.fontRendererObj.getStringWidth("/");


### PR DESCRIPTION
# Description
This turns the green 10/10 (which doesn't make sense) on no secrets room to 0/0 greyed
# Demostration
![https://cdn.robothanzo.dev/java_2ZmytrRGzy.png](https://cdn.robothanzo.dev/java_2ZmytrRGzy.png)
# Try It Out
[https://github.com/RobotHanzo/SkyblockAddons/suites/1358197246/artifacts/22113347](https://github.com/RobotHanzo/SkyblockAddons/suites/1358197246/artifacts/22113347)