### PR TITLE
Dungeon Improvement: Salvaged & Collected essences

### DIFF
--- a/src/main/java/codes/biscuit/skyblockaddons/asm/hooks/GuiChestHook.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/asm/hooks/GuiChestHook.java
@@ -32,7 +32,11 @@ import org.apache.commons.lang3.StringUtils;
 import org.lwjgl.input.Keyboard;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.Arrays;
+import java.util.EnumMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -64,7 +68,13 @@ public class GuiChestHook {
      * Resets variables when the chest is closed
      */
     public static void onGuiClosed() {
-        SkyblockAddons.getInstance().getInventoryUtils().updateInventoryType();
+        SkyblockAddons main = SkyblockAddons.getInstance();
+        InventoryType type = main.getInventoryUtils().updateInventoryType();
+
+        if (type == InventoryType.SALVAGING && main.getConfigValues().isEnabled(Feature.SHOW_SALVAGE_ESSENCES_COUNTER)) {
+            main.getDungeonUtils().getSalvagedEssences().clear();
+        }
+
         if (textFieldMatch != null && textFieldExclusions != null) {
             Keyboard.enableRepeatEvents(false);
         }

--- a/src/main/java/codes/biscuit/skyblockaddons/utils/DungeonUtils.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/utils/DungeonUtils.java
@@ -22,7 +22,7 @@ public class DungeonUtils {
     private static final Pattern PATTERN_MILESTONE = Pattern.compile("^.+?(Healer|Tank|Mage|Archer|Berserk) Milestone .+?([❶-❿]).+?§r§.(\\d+)§.§7 .+?");
     private static final Pattern PATTERN_COLLECTED_ESSENCES = Pattern.compile("§.+?(\\d+) (Wither|Spider|Undead|Dragon|Gold|Diamond|Ice) Essence");
     private static final Pattern PATTERN_BONUS_ESSENCE = Pattern.compile("^§.+?[^You] .+?found a .+?(Wither|Spider|Undead|Dragon|Gold|Diamond|Ice) Essence.+?");
-    private static final Pattern PATTERN_SALVAGE_ESSENCES = Pattern.compile("§.§.\\+([0-9])+? §.§.(Wither|Spider|Undead|Dragon|Gold|Diamond|Ice) Essence!+");
+    private static final Pattern PATTERN_SALVAGE_ESSENCES = Pattern.compile("\\+([0-9]+)? §.§.(Wither|Spider|Undead|Dragon|Gold|Diamond|Ice) Essence!");
     private static final Pattern PATTERN_SECRETS = Pattern.compile("§7([0-9]+)/([0-9]+) Secrets");
 
     /** The last dungeon server the player played on */
@@ -33,6 +33,13 @@ public class DungeonUtils {
 
     /** The latest essences the player collected during a dungeon game */
     @Getter private final Map<EssenceType, Integer> collectedEssences = new EnumMap<>(EssenceType.class);
+
+    /**
+     * Represents the number of essences from salvaged items by the player.
+     *
+     * It's in a separate map to avoid conflict with the collected map
+     */
+    @Getter private final Map<EssenceType, Integer> salvagedEssences = new EnumMap<>(EssenceType.class);
 
     /** The current teammates of the dungeon game */
     @Getter private final Map<String, DungeonPlayer> players = new HashMap<>();
@@ -158,7 +165,7 @@ public class DungeonUtils {
             EssenceType essenceType = EssenceType.fromName(matcher.group(2));
             int amount = Integer.parseInt(matcher.group(1));
 
-            collectedEssences.put(essenceType, collectedEssences.getOrDefault(essenceType, 0) + amount);
+            salvagedEssences.put(essenceType, salvagedEssences.getOrDefault(essenceType, 0) + amount);
         }
     }
 }

--- a/src/main/java/codes/biscuit/skyblockaddons/utils/Utils.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/utils/Utils.java
@@ -91,7 +91,7 @@ public class Utils {
             "telekinesis"
     ));
 
-    private static final Pattern SERVER_REGEX = Pattern.compile("(?<serverType>[Mm])(?<serverCode>[0-9]+[A-Z])$");
+    private static final Pattern SERVER_REGEX = Pattern.compile("([Mm])([0-9]+[A-Z])");
     private static final Pattern PURSE_REGEX = Pattern.compile("(?:Purse|Piggy): (?<coins>[0-9.]*)(?: .*)?");
     private static final Pattern SLAYER_TYPE_REGEX = Pattern.compile("(?<type>Tarantula Broodfather|Revenant Horror|Sven Packmaster) (?<level>[IV]+)");
     private static final Pattern SLAYER_PROGRESS_REGEX = Pattern.compile("(?<progress>[0-9.k]*)/(?<total>[0-9.k]*) (?:Kills|Combat XP)$");
@@ -306,13 +306,13 @@ public class Utils {
                     }
 
                     if ((matcher = SERVER_REGEX.matcher(strippedUnformatted)).find()) {
-                        String serverType = matcher.group("serverType");
+                        String serverType = matcher.group(1);
                         if (serverType.equals("m")) {
                             serverID = "mini";
                         } else if (serverType.equals("M")) {
                             serverID = "mega";
                         }
-                        serverID += matcher.group("serverCode");
+                        serverID += matcher.group(2);
                     }
 
                     if (strippedUnformatted.endsWith("Combat XP") || strippedUnformatted.endsWith("Kills")) {


### PR DESCRIPTION
- Improves the server ID detection to perform reset on collected essences counter
- Separate the salvage and collected counter to avoid conflicts in the future
- Fix: Salvage regex doesn't detect a number with more than one digit