### PR TITLE
[BUG FIX] Fixed axes with reforges not compatible with the cooldown features

### DIFF
--- a/src/main/java/codes/biscuit/skyblockaddons/asm/hooks/MinecraftHook.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/asm/hooks/MinecraftHook.java
@@ -170,8 +170,8 @@ public class MinecraftHook {
                 if ((block.equals(Blocks.log) || block.equals(Blocks.log2))
                         && p.getHeldItem() != null) {
 
-                    final boolean holdingJungleAxeOnCooldown = InventoryUtils.JUNGLE_AXE_DISPLAYNAME.equals(p.getHeldItem().getDisplayName()) && CooldownManager.isOnCooldown(InventoryUtils.JUNGLE_AXE_DISPLAYNAME);
-                    final boolean holdingTreecapitatorOnCooldown = InventoryUtils.TREECAPITATOR_DISPLAYNAME.equals(p.getHeldItem().getDisplayName()) && CooldownManager.isOnCooldown(InventoryUtils.TREECAPITATOR_DISPLAYNAME);
+                    final boolean holdingJungleAxeOnCooldown = p.getHeldItem().getDisplayName().contains(InventoryUtils.JUNGLE_AXE_DISPLAYNAME) && CooldownManager.isOnCooldown(p.getHeldItem().getDisplayName());
+                    final boolean holdingTreecapitatorOnCooldown = p.getHeldItem().getDisplayName().contains(InventoryUtils.TREECAPITATOR_DISPLAYNAME) && CooldownManager.isOnCooldown(p.getHeldItem().getDisplayName());
 
                     if (holdingJungleAxeOnCooldown || holdingTreecapitatorOnCooldown) {
                         returnValue.cancel();

--- a/src/main/java/codes/biscuit/skyblockaddons/asm/hooks/PlayerControllerMPHook.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/asm/hooks/PlayerControllerMPHook.java
@@ -67,7 +67,7 @@ public class PlayerControllerMPHook {
         if (heldItem != null) {
             Block block = mc.theWorld.getBlockState(loc).getBlock();
             if (main.getUtils().isOnSkyblock() && main.getConfigValues().isEnabled(Feature.SHOW_ITEM_COOLDOWNS) && (block.equals(Blocks.log) || block.equals(Blocks.log2))) {
-                if (InventoryUtils.JUNGLE_AXE_DISPLAYNAME.equals(heldItem.getDisplayName()) || InventoryUtils.TREECAPITATOR_DISPLAYNAME.equals(heldItem.getDisplayName())) {
+                if (heldItem.getDisplayName().contains(InventoryUtils.JUNGLE_AXE_DISPLAYNAME) || heldItem.getDisplayName().contains(InventoryUtils.TREECAPITATOR_DISPLAYNAME)) {
                     CooldownManager.put(heldItem);
                 }
             }

--- a/src/main/java/codes/biscuit/skyblockaddons/features/cooldowns/CooldownManager.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/features/cooldowns/CooldownManager.java
@@ -27,7 +27,12 @@ public class CooldownManager {
     }
 
     private static CooldownEntry get(String itemName) {
-        return cooldowns.getOrDefault(itemName, CooldownEntry.NULL_ENTRY);
+        for (Map.Entry<String, CooldownEntry> entry : cooldowns.entrySet()) {
+            if (itemName.contains(entry.getKey())) { // Check if the item name contains what we are trying to look for
+                return entry.getValue();
+            }
+        }
+        return CooldownEntry.NULL_ENTRY; // Return null entry if we found nothing
     }
 
     /**

--- a/src/main/java/codes/biscuit/skyblockaddons/utils/InventoryUtils.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/utils/InventoryUtils.java
@@ -42,8 +42,8 @@ public class InventoryUtils {
     private static final String TOXIC_ARROW_POISON_ID = "TOXIC_ARROW_POISON";
 
     public static final String MADDOX_BATPHONE_DISPLAYNAME = "§aMaddox Batphone";
-    public static final String JUNGLE_AXE_DISPLAYNAME = "§aJungle Axe";
-    public static final String TREECAPITATOR_DISPLAYNAME = "§5Treecapitator";
+    public static final String JUNGLE_AXE_DISPLAYNAME = "Jungle Axe";
+    public static final String TREECAPITATOR_DISPLAYNAME = "Treecapitator";
     public static final String CHICKEN_HEAD_DISPLAYNAME = "§fChicken Head";
 
     private static final Pattern REVENANT_UPGRADE_PATTERN = Pattern.compile("Next Upgrade: \\+([0-9]+❈) \\(([0-9,]+)/([0-9,]+)\\)");


### PR DESCRIPTION
# Description
This fixes Issue #438 by using .contains instead of .equals when matching axes, and replace the way it searches maps
# Try It Out
[https://github.com/RobotHanzo/SkyblockAddons/suites/1393459570/artifacts/23067682](https://github.com/RobotHanzo/SkyblockAddons/suites/1393459570/artifacts/23067682)