### PR TITLE
[New Feature] Block grappling on its cooldown

### DIFF
--- a/src/main/java/codes/biscuit/skyblockaddons/core/Feature.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/core/Feature.java
@@ -183,6 +183,8 @@ public enum Feature {
     HIDE_OTHER_PLAYERS_PRESENTS(150, "settings.hideOtherPlayersPresents", null,false),
     EASIER_PRESENT_OPENING(151, "settings.easierPresentOpening", null,false),
 
+    BLOCK_GRAPPLING_HOOK_ON_COOLDOWN(152, "settings.blockGrapplingHookOnCooldown", null, false),
+
     WARNING_TIME(-1, Message.SETTING_WARNING_DURATION, false),
 
     WARP_ADVANCED_MODE(-1, Message.SETTING_ADVANCED_MODE, true),

--- a/src/main/java/codes/biscuit/skyblockaddons/listeners/PlayerListener.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/listeners/PlayerListener.java
@@ -436,6 +436,11 @@ public class PlayerListener {
                     lastBobberEnteredWater = Long.MAX_VALUE;
                     oldBobberPosY = 0;
                 }
+                if (Objects.equals(ItemUtils.getSkyBlockItemID(heldItem), "GRAPPLING_HOOK")
+                        && main.getConfigValues().isEnabled(Feature.BLOCK_GRAPPLING_HOOK_ON_COOLDOWN)
+                        && CooldownManager.isOnCooldown(heldItem)) {
+                    e.setCanceled(true);
+                }
                 if (main.getConfigValues().isEnabled(Feature.SHOW_ITEM_COOLDOWNS) && mc.thePlayer.fishEntity != null) {
                     CooldownManager.put(mc.thePlayer.getHeldItem());
                 }

--- a/src/main/java/codes/biscuit/skyblockaddons/utils/EnumUtils.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/utils/EnumUtils.java
@@ -289,7 +289,8 @@ public class EnumUtils {
                 Feature.DUNGEONS_SECRETS_DISPLAY, Feature.SHOW_SALVAGE_ESSENCES_COUNTER, Feature.SHOW_SWORD_KILLS),
         TIRELESS_TRAVELER("TirelessTraveler", "github.com/ILikePlayingGames", Feature.DUNGEON_DEATH_COUNTER),
         KAASBROODJU("kaasbroodju", "github.com/kaasbroodju", Feature.SKILL_PROGRESS_BAR, Feature.SHOW_SKILL_PERCENTAGE_INSTEAD_OF_XP, Feature.SHOW_SKILL_XP_GAINED),
-        PHOUBE("Phoube", "github.com/Phoube", Feature.HIDE_OTHER_PLAYERS_PRESENTS, Feature.EASIER_PRESENT_OPENING);
+        PHOUBE("Phoube", "github.com/Phoube", Feature.HIDE_OTHER_PLAYERS_PRESENTS, Feature.EASIER_PRESENT_OPENING),
+        ROBOTHANZO("RobotHanzo", "robothanzo.dev", Feature.BLOCK_GRAPPLING_HOOK_ON_COOLDOWN);
 
         private Set<Feature> features;
         private String author;

--- a/src/main/resources/lang/en_us.json
+++ b/src/main/resources/lang/en_us.json
@@ -172,7 +172,8 @@
     "disableBossMessages": "Disable Boss Messages",
     "hideOtherPlayersPresents": "Hide Other Player's Presents",
     "easierPresentOpening": "Open Presents Easier",
-    "showSwordKills": "Show Sword Kills"
+    "showSwordKills": "Show Sword Kills",
+    "blockGrapplingHookOnCooldown": "Block Grappling Hook on Cooldown"
   },
   "messages": {
     "enchants": "Enchants",


### PR DESCRIPTION
# Description
When you sometimes forgot to look at the item cooldown durability bar, you'd accidentally fire grappling hook too fast and cause the slowness of the next one, this fixes it for you!
# Try It Out
[https://github.com/RobotHanzo/SkyblockAddons/suites/1407161752/artifacts/23449691](https://github.com/RobotHanzo/SkyblockAddons/suites/1407161752/artifacts/23449691)