### PR TITLE
Dungeon Fix: Found secrets are more then max

### DIFF
--- a/src/main/java/codes/biscuit/skyblockaddons/listeners/RenderListener.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/listeners/RenderListener.java
@@ -1,8 +1,20 @@
 package codes.biscuit.skyblockaddons.listeners;
 
 import codes.biscuit.skyblockaddons.SkyblockAddons;
-import codes.biscuit.skyblockaddons.core.*;
-import codes.biscuit.skyblockaddons.features.*;
+import codes.biscuit.skyblockaddons.core.Attribute;
+import codes.biscuit.skyblockaddons.core.DungeonClass;
+import codes.biscuit.skyblockaddons.core.DungeonMilestone;
+import codes.biscuit.skyblockaddons.core.DungeonPlayer;
+import codes.biscuit.skyblockaddons.core.EssenceType;
+import codes.biscuit.skyblockaddons.core.Feature;
+import codes.biscuit.skyblockaddons.core.Location;
+import codes.biscuit.skyblockaddons.core.Message;
+import codes.biscuit.skyblockaddons.core.Translations;
+import codes.biscuit.skyblockaddons.features.BaitManager;
+import codes.biscuit.skyblockaddons.features.DungeonDeathCounter;
+import codes.biscuit.skyblockaddons.features.EndstoneProtectorManager;
+import codes.biscuit.skyblockaddons.features.ItemDiff;
+import codes.biscuit.skyblockaddons.features.SlayerArmorProgress;
 import codes.biscuit.skyblockaddons.features.dragontracker.DragonTracker;
 import codes.biscuit.skyblockaddons.features.dragontracker.DragonType;
 import codes.biscuit.skyblockaddons.features.dragontracker.DragonsSince;
@@ -23,7 +35,11 @@ import codes.biscuit.skyblockaddons.misc.ChromaManager;
 import codes.biscuit.skyblockaddons.misc.Updater;
 import codes.biscuit.skyblockaddons.misc.scheduler.Scheduler;
 import codes.biscuit.skyblockaddons.misc.scheduler.SkyblockRunnable;
-import codes.biscuit.skyblockaddons.utils.*;
+import codes.biscuit.skyblockaddons.utils.ColorCode;
+import codes.biscuit.skyblockaddons.utils.EnumUtils;
+import codes.biscuit.skyblockaddons.utils.ItemUtils;
+import codes.biscuit.skyblockaddons.utils.TextUtils;
+import codes.biscuit.skyblockaddons.utils.Utils;
 import codes.biscuit.skyblockaddons.utils.objects.IntPair;
 import com.google.common.collect.Lists;
 import lombok.Getter;
@@ -32,7 +48,11 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Gui;
 import net.minecraft.client.gui.MapItemRenderer;
 import net.minecraft.client.gui.ScaledResolution;
-import net.minecraft.client.renderer.*;
+import net.minecraft.client.renderer.GlStateManager;
+import net.minecraft.client.renderer.OpenGlHelper;
+import net.minecraft.client.renderer.RenderHelper;
+import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.client.renderer.WorldRenderer;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.entity.Entity;
@@ -65,8 +85,16 @@ import org.lwjgl.opengl.GL11;
 import java.awt.*;
 import java.math.BigDecimal;
 import java.text.DecimalFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.LinkedList;
 import java.util.List;
-import java.util.*;
+import java.util.Map;
+import java.util.Optional;
+import java.util.TimeZone;
 
 import static net.minecraft.client.gui.Gui.icons;
 
@@ -1136,9 +1164,18 @@ public class RenderListener {
             if (secrets == -1) {
                 secrets = 10;
                 maxSecrets = 10;
+            } else {
+                if (secrets > maxSecrets) {
+                    // Assume the max secrets equals to found secrets
+                    // Prevent crash from dividing by zero (if max secrets equals to 0)
+                    maxSecrets = secrets;
+                } else if (secrets == 0 && maxSecrets == 0) { // Prevent crash from dividing zero by zero
+                    secrets = 10;
+                    maxSecrets = 10;
+                }
             }
 
-            float percent = secrets / (float) maxSecrets;
+            float percent = Math.min(1F, (float) secrets / (float) maxSecrets);
             float r;
             float g;
             if (percent <= 0.5) { // Fade from red -> yellow


### PR DESCRIPTION
Fixes #449

It appears that sometimes the found secrets number is bigger
then the max secrets in the dungeon room.

This patch fixes this bug and prevents similar cases in the future

- Fix: Both max/found secrets equals zero
- Fix: Max secrets equals zero

![image](https://user-images.githubusercontent.com/20463031/98740948-e94ea000-23bc-11eb-9a50-6196cf3da093.png)
_**Source: @TimoLob**_

**Notes:**
This patch is improved and based on https://github.com/TimoLob/SkyblockAddons/commit/4602c2dc5dea24752712105f180af469c025f0ff

_Fun Fact: I don't know how the imports were wildcarded in `RenderListener.java`_

Reviewed by @Phoube 😀 