### PR TITLE
fix: inject chroma check into Patcher method head

### DIFF
--- a/src/main/java/codes/biscuit/skyblockaddons/asm/FontRendererTransformer.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/asm/FontRendererTransformer.java
@@ -38,7 +38,7 @@ public class FontRendererTransformer implements ITransformer {
             // Find Method Head: Add:
             //   FontRendererHook.changeTextColor(); <- insert the call right before the return
 
-            if (TransformerMethod.renderChar.matches(methodNode)) {
+            if (TransformerMethod.renderChar.matches(methodNode) || methodNode.name.equals("renderChar")) {
                 methodNode.instructions.insertBefore(methodNode.instructions.getFirst(), insertChangeTextColor());
             }
 

--- a/src/main/java/codes/biscuit/skyblockaddons/tweaker/SkyblockAddonsTransformer.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/tweaker/SkyblockAddonsTransformer.java
@@ -89,11 +89,6 @@ public class SkyblockAddonsTransformer implements IClassTransformer {
         transformers.forEach(transformer -> {
             log(Level.INFO, String.format("Applying transformer %s on %s...", transformer.getClass().getName(), transformedName));
             transformer.transform(node, transformedName);
-
-            // Asm-ing into patcher's source code causes issues if the writer tries to compute stackmap frames for some reason...TODO is why it's a problem?
-            if (transformer instanceof FontRendererTransformer && transformedName.equals("club.sk1er.patcher.hooks.FontRendererHook")) {
-                classWriterFlags.setValue(0);
-            }
         });
 
         ClassWriter writer = new ClassWriter(classWriterFlags.getValue());


### PR DESCRIPTION
Super lazy fix that should work on Patcher 1.5-1.7

Injects the chroma check into the Patcher renderStringAtPos method head instead of in the MC code (since Patcher transformer runs later + Patcher is switching to mixin), I didn't want a change in transformer order to break something

Removes other injection into Patcher's methods since SBA never updates so it's likely to break at some point