### PR TITLE
Persist dev mode and fix backpack opening sound conflict

### DIFF
--- a/src/main/java/codes/biscuit/skyblockaddons/asm/hooks/GuiNewChatHook.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/asm/hooks/GuiNewChatHook.java
@@ -1,13 +1,14 @@
 package codes.biscuit.skyblockaddons.asm.hooks;
 
 import codes.biscuit.skyblockaddons.SkyblockAddons;
+import codes.biscuit.skyblockaddons.core.Feature;
 import net.minecraft.util.IChatComponent;
 
 public class GuiNewChatHook {
 
     public static String getUnformattedText(IChatComponent iChatComponent) {
         SkyblockAddons main = SkyblockAddons.getInstance();
-        if (main != null && main.isDevMode()) {
+        if (main != null && main.getConfigValues().isEnabled(Feature.DEVELOPER_MODE)) {
             return iChatComponent.getFormattedText(); // For logging colored messages...
         }
         return iChatComponent.getUnformattedText();

--- a/src/main/java/codes/biscuit/skyblockaddons/commands/SkyblockAddonsCommand.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/commands/SkyblockAddonsCommand.java
@@ -1,6 +1,7 @@
 package codes.biscuit.skyblockaddons.commands;
 
 import codes.biscuit.skyblockaddons.SkyblockAddons;
+import codes.biscuit.skyblockaddons.core.Feature;
 import codes.biscuit.skyblockaddons.core.Message;
 import codes.biscuit.skyblockaddons.core.Translations;
 import codes.biscuit.skyblockaddons.features.slayertracker.SlayerBoss;
@@ -77,7 +78,7 @@ public class SkyblockAddonsCommand extends CommandBase {
                 "§b● " + CommandSyntax.VERSION + " §7- " + Translations.getMessage("commandUsage.sba.version.help") + "\n" +
                 "§b● " + CommandSyntax.DEV + " §7- " + Translations.getMessage("commandUsage.sba.dev.help");
 
-        if (main.isDevMode()) {
+        if (main.getConfigValues().isEnabled(Feature.DEVELOPER_MODE)) {
             usage = usage + "\n" +
                     "§b● " + CommandSyntax.BRAND + " §7- " + getDevPrefixFormatted() + Translations.getMessage("commandUsage.sba.brand.help") + "\n" +
                     "§b● " + CommandSyntax.COPY_BLOCK + " §7- " + getDevPrefixFormatted() +  Translations.getMessage("commandUsage.sba.copyBlock.help") + "\n" +
@@ -134,7 +135,7 @@ public class SkyblockAddonsCommand extends CommandBase {
                 }
                 return getListOfStringsMatchingLastWord(args, slayers);
 
-            } else if (main.isDevMode()) {
+            } else if (main.getConfigValues().isEnabled(Feature.DEVELOPER_MODE)) {
                 if (args[0].equalsIgnoreCase("copyEntity")) {
                     return getListOfStringsMatchingLastWord(args, DevUtils.ALL_ENTITY_NAMES);
                 } else if (args[0].equalsIgnoreCase("copySidebar")) {
@@ -184,14 +185,12 @@ public class SkyblockAddonsCommand extends CommandBase {
 
                 } else if (args[0].equalsIgnoreCase("dev") || args[0].equalsIgnoreCase("nbt")) {
                     SkyblockKeyBinding devModeKeyBinding = main.getDeveloperCopyNBTKey();
-                    main.setDevMode(!main.isDevMode());
+                    Feature.DEVELOPER_MODE.setEnabled(main.getConfigValues().isEnabled(Feature.DEVELOPER_MODE));
 
-                    if (main.isDevMode()) {
-                        devModeKeyBinding.register();
+                    if (main.getConfigValues().isEnabled(Feature.DEVELOPER_MODE)) {
                         main.getUtils().sendMessage(ColorCode.GREEN + Translations.getMessage("commandUsage.sba.dev.enabled",
                                 GameSettings.getKeyDisplayString(devModeKeyBinding.getKeyCode())));
                     } else {
-                        devModeKeyBinding.deRegister();
                         main.getUtils().sendMessage(ColorCode.RED + Translations.getMessage("commandUsage.sba.dev.disabled"));
                     }
                 } else if (args[0].equalsIgnoreCase("resetZealotCounter")) {
@@ -275,7 +274,7 @@ public class SkyblockAddonsCommand extends CommandBase {
                      the user chooses to copy for diagnostic purposes.
                      */
                     main.getUtils().sendMessage(versionChatComponent, true);
-                } else if (main.isDevMode()) {
+                } else if (main.getConfigValues().isEnabled(Feature.DEVELOPER_MODE)) {
                     if (args[0].equalsIgnoreCase("brand")) {
                         String serverBrand = DevUtils.getServerBrand();
 
@@ -391,7 +390,7 @@ public class SkyblockAddonsCommand extends CommandBase {
      Developer mode commands are not included if developer mode is disabled.
      */
     private List<String> getSubCommandTabCompletionOptions(String[] args) {
-        if (main.isDevMode()) {
+        if (main.getConfigValues().isEnabled(Feature.DEVELOPER_MODE)) {
             return getListOfStringsMatchingLastWord(args, SUBCOMMANDS);
         } else {
             return getListOfStringsMatchingLastWord(args, Arrays.copyOf(SUBCOMMANDS, 7));

--- a/src/main/java/codes/biscuit/skyblockaddons/core/Feature.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/core/Feature.java
@@ -4,6 +4,7 @@ import codes.biscuit.skyblockaddons.SkyblockAddons;
 import codes.biscuit.skyblockaddons.features.EntityOutlines.FeatureTrackerQuest;
 import codes.biscuit.skyblockaddons.features.dungeonmap.DungeonMapManager;
 import codes.biscuit.skyblockaddons.gui.buttons.ButtonLocation;
+import codes.biscuit.skyblockaddons.misc.SkyblockKeyBinding;
 import codes.biscuit.skyblockaddons.utils.ColorCode;
 import codes.biscuit.skyblockaddons.utils.EnumUtils;
 import com.google.common.collect.Sets;
@@ -210,6 +211,9 @@ public enum Feature {
     BAL_BOSS_ALERT(208, Message.SETTING_BAL_BOSS_WARNING, false),
     OUTBID_ALERT_SOUND_IN_OTHER_GAMES(209, null, false),
     DONT_REPLACE_ROMAN_NUMERALS_IN_ITEM_NAME(210, "settings.dontReplaceRomanNumeralsInItemNames", null, true),
+    BACKPACK_OPENING_SOUND(211, "settings.backpackOpeningSound", null, false),
+    DEVELOPER_MODE(212, "settings.devMode", null, true),
+    SHOW_SKYBLOCK_ITEM_ID(213, "settings.showSkyblockItemId", null, true),
 
     WARNING_TIME(-1, Message.SETTING_WARNING_DURATION, false),
     WARP_ADVANCED_MODE(-1, Message.SETTING_ADVANCED_MODE, true),
@@ -274,9 +278,9 @@ public enum Feature {
      */
     @Getter
     private static final Set<Feature> generalTabFeatures = new LinkedHashSet<>(Arrays.asList(TEXT_STYLE, WARNING_TIME, CHROMA_SPEED, CHROMA_MODE,
-            CHROMA_SIZE, TURN_ALL_FEATURES_CHROMA, CHROMA_SATURATION, CHROMA_BRIGHTNESS, USE_NEW_CHROMA_EFFECT));
+            CHROMA_SIZE, TURN_ALL_FEATURES_CHROMA, CHROMA_SATURATION, CHROMA_BRIGHTNESS, USE_NEW_CHROMA_EFFECT, DEVELOPER_MODE));
 
-    private static final int ID_AT_PREVIOUS_UPDATE = 98;
+    private static final int ID_AT_PREVIOUS_UPDATE = 199;
 
     private final int id;
     private Message message;
@@ -319,6 +323,36 @@ public enum Feature {
 
     Feature(int id, Message settingMessage, boolean defaultDisabled, EnumUtils.FeatureSetting... settings) {
         this(id, settingMessage,null, defaultDisabled, settings);
+    }
+
+    /**
+     * Called when a features enable state is changed.
+     */
+    public void onToggle() {
+        if (this.id == DEVELOPER_MODE.id) {
+            SkyblockAddons main = SkyblockAddons.getInstance();
+            SkyblockKeyBinding devModeKeyBinding = main.getDeveloperCopyNBTKey();
+
+            if (main.getConfigValues().isEnabled(DEVELOPER_MODE)) {
+                devModeKeyBinding.register();
+            } else {
+                devModeKeyBinding.deRegister();
+            }
+        }
+    }
+
+    /**
+     * Sets whether the current feature is enabled.
+     *
+     * @param enabled {@code true} to enable the feature, {@code false} to disable it
+     */
+    public void setEnabled(boolean enabled) {
+        if (enabled) {
+            SkyblockAddons.getInstance().getConfigValues().getDisabledFeatures().remove(this);
+        } else {
+            SkyblockAddons.getInstance().getConfigValues().getDisabledFeatures().add(this);
+        }
+        onToggle();
     }
 
     public boolean isActualFeature() {

--- a/src/main/java/codes/biscuit/skyblockaddons/gui/EnchantmentSettingsGui.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/gui/EnchantmentSettingsGui.java
@@ -163,11 +163,7 @@ public class EnchantmentSettingsGui extends SettingsGui {
             ButtonFeature button = (ButtonFeature) abstractButton;
             Feature feature = button.getFeature();
             if (feature == null) return;
-            if (main.getConfigValues().isDisabled(feature)) {
-                main.getConfigValues().getDisabledFeatures().remove(feature);
-            } else {
-                main.getConfigValues().getDisabledFeatures().add(feature);
-            }
+            feature.setEnabled(!main.getConfigValues().isEnabled(feature));
         } else if (abstractButton instanceof ButtonArrow) {
             ButtonArrow arrow = (ButtonArrow) abstractButton;
             if (arrow.isNotMax()) {

--- a/src/main/java/codes/biscuit/skyblockaddons/gui/IslandWarpGui.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/gui/IslandWarpGui.java
@@ -138,23 +138,11 @@ public class IslandWarpGui extends GuiScreen {
                     }));
             this.buttonList.add(new ButtonToggleNew(x, y - 30 - 60 * 2, 50,
                     () -> main.getConfigValues().isEnabled(Feature.FANCY_WARP_MENU),
-                    () -> {
-                        if (main.getConfigValues().getDisabledFeatures().contains(Feature.FANCY_WARP_MENU)) {
-                            main.getConfigValues().getDisabledFeatures().remove(Feature.FANCY_WARP_MENU);
-                        } else {
-                            main.getConfigValues().getDisabledFeatures().add(Feature.FANCY_WARP_MENU);
-                        }
-                    }));
+                    () -> Feature.FANCY_WARP_MENU.setEnabled(!main.getConfigValues().isEnabled(Feature.FANCY_WARP_MENU))));
         }
         this.buttonList.add(new ButtonToggleNew(x, y - 30 - 60, 50,
                 () -> main.getConfigValues().isEnabled(Feature.DOUBLE_WARP),
-                () -> {
-                    if (main.getConfigValues().getDisabledFeatures().contains(Feature.DOUBLE_WARP)) {
-                        main.getConfigValues().getDisabledFeatures().remove(Feature.DOUBLE_WARP);
-                    } else {
-                        main.getConfigValues().getDisabledFeatures().add(Feature.DOUBLE_WARP);
-                    }
-                }));
+                () -> Feature.DOUBLE_WARP.setEnabled(!main.getConfigValues().isEnabled(Feature.DOUBLE_WARP))));
     }
 
     @Override

--- a/src/main/java/codes/biscuit/skyblockaddons/gui/LocationEditGui.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/gui/LocationEditGui.java
@@ -376,7 +376,7 @@ public class LocationEditGui extends GuiScreen {
 
                             if (thisSnap.getHeight() < SNAPPING_RADIUS) {
                                 if (horizontalSnap == null || thisSnap.getHeight() < horizontalSnap.getHeight()) {
-                                    if (main.isDevMode()) {
+                                    if (main.getConfigValues().isEnabled(Feature.DEVELOPER_MODE)) {
                                         DrawUtils.drawRectAbsolute(snapX - 0.5, 0, snapX + 0.5, mc.displayHeight, 0xFF0000FF);
                                     }
                                     horizontalSnap = thisSnap;
@@ -408,7 +408,7 @@ public class LocationEditGui extends GuiScreen {
 
                             if (thisSnap.getWidth() < SNAPPING_RADIUS) {
                                 if (verticalSnap == null || thisSnap.getWidth() < verticalSnap.getWidth()) {
-                                    if (main.isDevMode()) {
+                                    if (main.getConfigValues().isEnabled(Feature.DEVELOPER_MODE)) {
                                         DrawUtils.drawRectAbsolute(0, snapY - 0.5, mc.displayWidth, snapY + 0.5, 0xFF0000FF);
                                     }
                                     verticalSnap = thisSnap;

--- a/src/main/java/codes/biscuit/skyblockaddons/gui/SettingsGui.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/gui/SettingsGui.java
@@ -193,9 +193,9 @@ public class SettingsGui extends GuiScreen {
             Feature feature = button.getFeature();
             if (feature == null) return;
             if (main.getConfigValues().isDisabled(feature)) {
-                main.getConfigValues().getDisabledFeatures().remove(feature);
+                feature.setEnabled(true);
             } else {
-                main.getConfigValues().getDisabledFeatures().add(feature);
+                feature.setEnabled(false);
                 if (feature == Feature.HIDE_FOOD_ARMOR_BAR) { // Reset the vanilla bars when disabling these two features.
                     GuiIngameForge.renderArmor = true; // The food gets automatically enabled, no need to include it.
                 } else if (feature == Feature.HIDE_HEALTH_BAR) {
@@ -348,7 +348,6 @@ public class SettingsGui extends GuiScreen {
             if (currentStatus == DiscordStatus.AUTO_STATUS) {
                 row++;
                 row += 0.4;
-                boxWidth = 140;
                 x = halfWidth - (boxWidth / 2);
                 y = getRowHeightSetting(row);
 
@@ -380,6 +379,8 @@ public class SettingsGui extends GuiScreen {
 
             row += 0.4;
         } else if (setting == EnumUtils.FeatureSetting.MAP_ZOOM) {
+            // For clarity
+            //noinspection ConstantConditions
             boxWidth = 100; // Default size and stuff.
             x = halfWidth - (boxWidth / 2);
             y = getRowHeightSetting(row);

--- a/src/main/java/codes/biscuit/skyblockaddons/gui/SkyblockAddonsGui.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/gui/SkyblockAddonsGui.java
@@ -225,14 +225,14 @@ public class SkyblockAddonsGui extends GuiScreen {
             } else if (abstractButton instanceof ButtonToggle) {
                 if (main.getConfigValues().isRemoteDisabled(feature)) return;
                 if (main.getConfigValues().isDisabled(feature)) {
-                    main.getConfigValues().getDisabledFeatures().remove(feature);
+                    feature.setEnabled(true);
                     if(feature == Feature.DISCORD_RPC && main.getUtils().isOnSkyblock()) {
                         main.getDiscordRPCManager().start();
                     } else if (feature == Feature.ZEALOT_COUNTER_EXPLOSIVE_BOW_SUPPORT) {
-                        main.getConfigValues().getDisabledFeatures().remove(Feature.DISABLE_ENDERMAN_TELEPORTATION_EFFECT);
+                        Feature.DISABLE_ENDERMAN_TELEPORTATION_EFFECT.setEnabled(true);
                     }
                 } else {
-                    main.getConfigValues().getDisabledFeatures().add(feature);
+                    feature.setEnabled(false);
                     if (feature == Feature.HIDE_FOOD_ARMOR_BAR) { // Reset the vanilla bars when disabling these two features.
                         GuiIngameForge.renderArmor = true; // The food gets automatically enabled, no need to include it.
                     } else if (feature == Feature.HIDE_HEALTH_BAR) {
@@ -243,7 +243,7 @@ public class SkyblockAddonsGui extends GuiScreen {
                     } else if(feature == Feature.DISCORD_RPC) {
                         main.getDiscordRPCManager().stop();
                     } else if (feature == Feature.DISABLE_ENDERMAN_TELEPORTATION_EFFECT) {
-                        main.getConfigValues().getDisabledFeatures().remove(Feature.ZEALOT_COUNTER_EXPLOSIVE_BOW_SUPPORT);
+                        Feature.ZEALOT_COUNTER_EXPLOSIVE_BOW_SUPPORT.setEnabled(true);
                     }
                 }
                 ((ButtonToggle)abstractButton).onClick();

--- a/src/main/java/codes/biscuit/skyblockaddons/listeners/GuiScreenListener.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/listeners/GuiScreenListener.java
@@ -37,6 +37,10 @@ public class GuiScreenListener {
     @Getter
     private long lastContainerCloseMs = -1;
 
+    /** Time in milliseconds of the last time a backpack was opened, used by {@link Feature#BACKPACK_OPENING_SOUND}. */
+    @Getter
+    private long lastBackpackOpenMs = -1;
+
     @SubscribeEvent
     public void beforeInit(GuiScreenEvent.InitGuiEvent.Pre e) {
         if (!main.getUtils().isOnSkyblock()) {
@@ -52,8 +56,10 @@ public class GuiScreenListener {
             InventoryBasic chestInventory = (InventoryBasic) guiChest.lowerChestInventory;
 
             // Backpack opening sound
-            if (chestInventory.hasCustomName()) {
+            if (main.getConfigValues().isEnabled(Feature.BACKPACK_OPENING_SOUND) && chestInventory.hasCustomName()) {
                 if (chestInventory.getDisplayName().getUnformattedText().contains("Backpack")) {
+                    lastBackpackOpenMs = System.currentTimeMillis();
+
                     if (ThreadLocalRandom.current().nextInt(0, 2) == 0) {
                         mc.thePlayer.playSound("mob.horse.armor", 0.5F, 1);
                     } else {
@@ -105,7 +111,7 @@ public class GuiScreenListener {
     public void onKeyInput(GuiScreenEvent.KeyboardInputEvent.Pre event) {
         int eventKey = Keyboard.getEventKey();
 
-        if (main.isDevMode() && eventKey == main.getDeveloperCopyNBTKey().getKeyCode() && Keyboard.getEventKeyState()) {
+        if (main.getConfigValues().isEnabled(Feature.DEVELOPER_MODE) && eventKey == main.getDeveloperCopyNBTKey().getKeyCode() && Keyboard.getEventKeyState()) {
             // Copy Item NBT
             GuiScreen currentScreen = event.gui;
 

--- a/src/main/resources/lang/en_US.json
+++ b/src/main/resources/lang/en_US.json
@@ -213,7 +213,10 @@
     "otherDefenseStats": "Other Defense Stats (Soul Tether/Cell Alignment)",
     "hideSpawnPointPlayers": "Hide Players at Hub Spawn Point",
     "jacobsContestTimer": "Jacob's Contest Timer",
-    "dontReplaceRomanNumeralsInItemNames": "Don't Replace in Item Names"
+    "dontReplaceRomanNumeralsInItemNames": "Don't Replace in Item Names",
+    "backpackOpeningSound": "Leather Backpack Opening Sound",
+    "devMode": "Developer Mode",
+    "showSkyblockItemId": "Show Skyblock Item ID on Hover"
   },
   "messages": {
     "enchants": "Enchants",


### PR DESCRIPTION
- Make dev mode setting persist across restarts
- Add dev mode toggle in general settings
- Separate show Skyblock item ID feature from dev mode
- Add a toggle for leather backpack opening sound
- Fix leather backpack opening sound conflicting with default Skyblock backpack opening sound
- Fix some warnings
- Simplify enabling/disabling features