### PR TITLE
Jsdelivr has been DNS pollution in China.

### DIFF
--- a/src/main/java/codes/biscuit/skyblockaddons/utils/data/DataConstants.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/utils/data/DataConstants.java
@@ -1,6 +1,6 @@
 package codes.biscuit.skyblockaddons.utils.data;
 
 class DataConstants {
-    static final String CDN_BASE_URL = "https://cdn.jsdelivr.net/gh/BiscuitDevelopment/SkyblockAddons-Data/";
+    static final String CDN_BASE_URL = "https://fastly.jsdelivr.net/gh/BiscuitDevelopment/SkyblockAddons-Data/";
     static final String GITHUB_BASE_URL = "https://raw.githubusercontent.com/BiscuitDevelopment/SkyblockAddons-Data/main/";
 }


### PR DESCRIPTION
Jsdelivr has been DNS pollution in China. But fortunately, `fastly.jsdelivr.net` is not polluted at present.Try to converted `cdn` to `fastly`?