### PR TITLE
Profile Type Icon In Chat + Typo Fix

### DIFF
--- a/src/main/java/codes/biscuit/skyblockaddons/core/Feature.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/core/Feature.java
@@ -216,6 +216,7 @@ public enum Feature {
     SHOW_SKYBLOCK_ITEM_ID(213, "settings.showSkyblockItemId", null, true),
     RESET_SALVAGED_ESSENCES_AFTER_LEAVING_MENU(214, "settings.resetSalvagedEssencesAfterLeavingMenu", null, false),
     CHANGE_DUNGEON_MAP_ZOOM_WITH_KEYBOARD(215, "settings.changeDungeonMapZoomWithKeyboard", null, false),
+    PROFILE_TYPE_IN_CHAT(216, "settings.showProfileTypeInChat", null, true),
 
     WARNING_TIME(-1, "settings.warningDuration", null, false),
     WARP_ADVANCED_MODE(-1, "settings.advancedMode", null, true),

--- a/src/main/java/codes/biscuit/skyblockaddons/features/itemdrops/ItemDropChecker.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/features/itemdrops/ItemDropChecker.java
@@ -188,7 +188,7 @@ public class ItemDropChecker {
         ColorCode colorCode = main.getConfigValues().getRestrictedColor(Feature.DROP_CONFIRMATION);
 
         if (attemptsRequiredToConfirm >= 2) {
-            String multipleAttemptsRequiredMessage = Translations.getMessage("messages,clickMoreTimes", Integer.toString(attemptsRequiredToConfirm));
+            String multipleAttemptsRequiredMessage = Translations.getMessage("messages.clickMoreTimes", Integer.toString(attemptsRequiredToConfirm));
             main.getUtils().sendMessage(colorCode + multipleAttemptsRequiredMessage);
 
         } else {

--- a/src/main/java/codes/biscuit/skyblockaddons/listeners/PlayerListener.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/listeners/PlayerListener.java
@@ -402,8 +402,21 @@ public class PlayerListener {
                             !fetchur.hasFetchedToday() && unformattedText.contains(fetchur.getFetchurAlreadyDidTaskPhrase())) {
                         FetchurManager.getInstance().saveLastTimeFetched();
                     }
+                // Tries to check if a message is from a player to add the player profile icon
+                } else if (main.getConfigValues().isEnabled(Feature.PROFILE_TYPE_IN_CHAT) &&
+                        unformattedText.contains(":")) {
+                    String username = unformattedText.split(":")[0].replaceAll("§.","");
+                    // Remove rank prefix if exists
+                    if (username.contains("]"))
+                        username = username.split("] ")[1];
+                    System.out.println(username);
+                    // Check if stripped username is a real username or the player
+                    if (TextUtils.isUsername(username) || username.equals("**MINECRAFTUSERNAME**")) {
+                        EntityPlayer chattingPlayer = Minecraft.getMinecraft().theWorld.getPlayerEntityByName(username);
+                        if(chattingPlayer != null)
+                            e.message = new ChatComponentText(formattedText.replace(username,chattingPlayer.getDisplayName().getSiblings().get(0).getUnformattedText()));
+                    }
                 }
-
 
                 if (main.getConfigValues().isEnabled(Feature.NO_ARROWS_LEFT_ALERT)) {
                     if (NO_ARROWS_LEFT_PATTERN.matcher(formattedText).matches()) {

--- a/src/main/java/codes/biscuit/skyblockaddons/listeners/PlayerListener.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/listeners/PlayerListener.java
@@ -419,7 +419,6 @@ public class PlayerListener {
                     // Remove rank prefix if exists
                     if (username.contains("]"))
                         username = username.split("] ")[1];
-                    System.out.println(username);
                     // Check if stripped username is a real username or the player
                     if (TextUtils.isUsername(username) || username.equals("**MINECRAFTUSERNAME**")) {
                         EntityPlayer chattingPlayer = Minecraft.getMinecraft().theWorld.getPlayerEntityByName(username);
@@ -431,7 +430,6 @@ public class PlayerListener {
                         }else if(namesWithType.containsKey(username)){
                             e.message = new ChatComponentText(formattedText.replace(username, namesWithType.get(username)));
                         }
-                        System.out.println(namesWithType.entrySet().toString());
                     }
                 }
 

--- a/src/main/java/codes/biscuit/skyblockaddons/listeners/PlayerListener.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/listeners/PlayerListener.java
@@ -415,7 +415,6 @@ public class PlayerListener {
                 // Tries to check if a message is from a player to add the player profile icon
                 } else if (main.getConfigValues().isEnabled(Feature.PROFILE_TYPE_IN_CHAT) &&
                         unformattedText.contains(":")) {
-                    System.out.println(e.message.getFormattedText()+"\n "+e.message.getChatStyle()+"\n "+e.message.getSiblings());
                     String username = unformattedText.split(":")[0].replaceAll("§.","");
                     // Remove rank prefix if exists
                     if (username.contains("]"))

--- a/src/main/java/codes/biscuit/skyblockaddons/listeners/PlayerListener.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/listeners/PlayerListener.java
@@ -415,6 +415,7 @@ public class PlayerListener {
                 // Tries to check if a message is from a player to add the player profile icon
                 } else if (main.getConfigValues().isEnabled(Feature.PROFILE_TYPE_IN_CHAT) &&
                         unformattedText.contains(":")) {
+                    System.out.println(e.message.getFormattedText()+"\n "+e.message.getChatStyle()+"\n "+e.message.getSiblings());
                     String username = unformattedText.split(":")[0].replaceAll("§.","");
                     // Remove rank prefix if exists
                     if (username.contains("]"))
@@ -422,13 +423,15 @@ public class PlayerListener {
                     // Check if stripped username is a real username or the player
                     if (TextUtils.isUsername(username) || username.equals("**MINECRAFTUSERNAME**")) {
                         EntityPlayer chattingPlayer = Minecraft.getMinecraft().theWorld.getPlayerEntityByName(username);
+                        // Put player in cache if found nearby
                         if(chattingPlayer != null) {
-                            String nameWithType = chattingPlayer.getDisplayName().getSiblings().get(0).getUnformattedText();
-                            e.message = new ChatComponentText(formattedText.replace(username, nameWithType));
-                            // Cache
                             namesWithType.put(username, chattingPlayer.getDisplayName().getSiblings().get(0).getUnformattedText());
-                        }else if(namesWithType.containsKey(username)){
+                        }
+                        // Check cache regardless if found nearby
+                        if(namesWithType.containsKey(username)){
+                            IChatComponent oldMessage = e.message;
                             e.message = new ChatComponentText(formattedText.replace(username, namesWithType.get(username)));
+                            e.message.setChatStyle(oldMessage.getChatStyle());
                         }
                     }
                 }

--- a/src/main/java/codes/biscuit/skyblockaddons/listeners/PlayerListener.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/listeners/PlayerListener.java
@@ -192,6 +192,16 @@ public class PlayerListener {
     private final SkyblockAddons main = SkyblockAddons.getInstance();
     private final ActionBarParser actionBarParser = new ActionBarParser();
 
+    // For caching for the PROFILE_TYPE_IN_CHAT feature, saves the last MAX_SIZE names.
+    private final LinkedHashMap<String, String> namesWithType = new LinkedHashMap<String, String>(){
+        private final int MAX_SIZE = 80;
+
+        protected boolean removeEldestEntry(Map.Entry<String, String> eldest)
+        {
+            return size() > MAX_SIZE;
+        }
+    };
+
     /**
      * Reset all the timers and stuff when joining a new world.
      */
@@ -413,8 +423,15 @@ public class PlayerListener {
                     // Check if stripped username is a real username or the player
                     if (TextUtils.isUsername(username) || username.equals("**MINECRAFTUSERNAME**")) {
                         EntityPlayer chattingPlayer = Minecraft.getMinecraft().theWorld.getPlayerEntityByName(username);
-                        if(chattingPlayer != null)
-                            e.message = new ChatComponentText(formattedText.replace(username,chattingPlayer.getDisplayName().getSiblings().get(0).getUnformattedText()));
+                        if(chattingPlayer != null) {
+                            String nameWithType = chattingPlayer.getDisplayName().getSiblings().get(0).getUnformattedText();
+                            e.message = new ChatComponentText(formattedText.replace(username, nameWithType));
+                            // Cache
+                            namesWithType.put(username, chattingPlayer.getDisplayName().getSiblings().get(0).getUnformattedText());
+                        }else if(namesWithType.containsKey(username)){
+                            e.message = new ChatComponentText(formattedText.replace(username, namesWithType.get(username)));
+                        }
+                        System.out.println(namesWithType.entrySet().toString());
                     }
                 }
 

--- a/src/main/java/codes/biscuit/skyblockaddons/utils/EnumUtils.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/utils/EnumUtils.java
@@ -329,7 +329,8 @@ public class EnumUtils {
         IRONM00N("IRONM00N", "github.com/IRONM00N", Feature.FARM_EVENT_TIMER),
         SKYCATMINEPOKIE("skycatminepokie", "github.com/skycatminepokie", Feature.OUTBID_ALERT_SOUND),
         TIMOLOB("TimoLob", "github.com/TimoLob", Feature.BROOD_MOTHER_ALERT),
-        NOPOTHEGAMER("NopoTheGamer", "twitch.tv/nopothegamer", Feature.BAL_BOSS_ALERT);
+        NOPOTHEGAMER("NopoTheGamer", "twitch.tv/nopothegamer", Feature.BAL_BOSS_ALERT),
+        CATFACE("CatFace","github.com/CattoFace",Feature.PROFILE_TYPE_IN_CHAT);
 
         private final Set<Feature> features;
         private final String author;

--- a/src/main/resources/lang/en_US.json
+++ b/src/main/resources/lang/en_US.json
@@ -219,7 +219,8 @@
     "showSkyblockItemId": "Show Skyblock Item ID on Hover",
     "showFeatureNamesOnHover": "Show Feature Names on Hover",
     "resetSalvagedEssencesAfterLeavingMenu": "Reset Salvaged Essence Counter After Closing Menu",
-    "changeDungeonMapZoomWithKeyboard": "Adjust zoom with +/- keys"
+    "changeDungeonMapZoomWithKeyboard": "Adjust zoom with +/- keys",
+    "showProfileTypeInChat": "Show Profile Type In Chat"
   },
   "messages": {
     "enchants": "Enchants",

--- a/src/main/resources/lang/he_IL.json
+++ b/src/main/resources/lang/he_IL.json
@@ -219,7 +219,8 @@
     "showSkyblockItemId": "Show Skyblock Item ID on Hover",
     "showFeatureNamesOnHover": "Show Feature Names on Hover",
     "resetSalvagedEssencesAfterLeavingMenu": "Reset Salvaged Essence Counter After Closing Menu",
-    "changeDungeonMapZoomWithKeyboard": "Adjust zoom with +/- keys"
+    "changeDungeonMapZoomWithKeyboard": "Adjust zoom with +/- keys",
+    "showProfileTypeInChat": "הוסף סוג פרופיל לצאט"
   },
   "messages": {
     "enchants": "כישופים",

--- a/src/main/resources/lang/he_IL.json
+++ b/src/main/resources/lang/he_IL.json
@@ -219,8 +219,7 @@
     "showSkyblockItemId": "Show Skyblock Item ID on Hover",
     "showFeatureNamesOnHover": "Show Feature Names on Hover",
     "resetSalvagedEssencesAfterLeavingMenu": "Reset Salvaged Essence Counter After Closing Menu",
-    "changeDungeonMapZoomWithKeyboard": "Adjust zoom with +/- keys",
-    "showProfileTypeInChat": "הוסף סוג פרופיל לצאט"
+    "changeDungeonMapZoomWithKeyboard": "Adjust zoom with +/- keys"
   },
   "messages": {
     "enchants": "כישופים",


### PR DESCRIPTION
Added a feature to display the profile type of a player in chat (ironman/bingo).
The feature requires the other player to be loaded for the icon to appear and there is a cache of recent players to keep the icon in case one goes so far they unload or they leave the lobby.

Also fixed a string typo in the item dropping feature that caused an unwanted string to print instead of a localized one,