### PR TITLE
Fixed issues with dungeon map zoom caused by impromper normalization.

### DIFF
--- a/src/main/java/codes/biscuit/skyblockaddons/features/dungeonmap/DungeonMapManager.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/features/dungeonmap/DungeonMapManager.java
@@ -33,6 +33,8 @@ import java.util.*;
 
 public class DungeonMapManager {
 
+    public static final float MIN_ZOOM = 0.5f;
+    public static final float MAX_ZOOM = 5f;
     private static final SkyblockAddons main = SkyblockAddons.getInstance();
     private static final ResourceLocation DUNGEON_MAP = new ResourceLocation("skyblockaddons", "dungeonsmap.png");
     private static final Comparator<MapMarker> MAP_MARKER_COMPARATOR = (first, second) -> {
@@ -492,16 +494,14 @@ public class DungeonMapManager {
      * Increases the zoom level of the dungeon map by 0.5.
      */
     public static void increaseZoomByStep() {
-        float zoomScaleFactor = MathUtils.denormalizeSliderValue(getMapZoom(), 0.5F, 5F, 0.1F);
-        setMapZoom(zoomScaleFactor + 0.5F);
+        setDenormalizedMapZoom(getDenormalizedMapZoom() + 0.5F);
     }
 
     /**
      * Decreases the zoom level of the dungeon map by 0.5.
      */
     public static void decreaseZoomByStep() {
-        float zoomScaleFactor = MathUtils.denormalizeSliderValue(main.getConfigValues().getMapZoom().getValue(), 0.5F, 5F, 0.1F);
-        setMapZoom(zoomScaleFactor - 0.5F);
+        setDenormalizedMapZoom(getDenormalizedMapZoom() - 0.5F);
     }
 
     /**
@@ -514,13 +514,25 @@ public class DungeonMapManager {
     }
 
     /**
+     * Returns the denormalized map zoom factor
+     * @return he denormalized map zoom factor
+     */
+    public static float getDenormalizedMapZoom(){
+        return MathUtils.denormalizeSliderValue(getMapZoom(), MIN_ZOOM, MAX_ZOOM, 0.1F);
+    }
+
+    public static void setDenormalizedMapZoom(float value){
+        setMapZoom(MathUtils.normalizeSliderValue(value, MIN_ZOOM, MAX_ZOOM,0.1F));
+    }
+
+    /**
      * Sets the map zoom factor in {@link codes.biscuit.skyblockaddons.config.ConfigValues#mapZoom}.
      * The new value must be between 0.5f and 5f inclusive.
      *
      * @param value the new map zoom factor
      */
     public static void setMapZoom(float value) {
-        main.getConfigValues().getMapZoom().setValue(main.getUtils().normalizeValueNoStep(value, 0.5F, 5F));
+        main.getConfigValues().getMapZoom().setValue(value);
         main.getConfigValues().saveConfig();
     }
 }

--- a/src/main/java/codes/biscuit/skyblockaddons/gui/SettingsGui.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/gui/SettingsGui.java
@@ -391,7 +391,7 @@ public class SettingsGui extends GuiScreen {
             boxWidth = 100; // Default size and stuff.
             x = halfWidth - (boxWidth / 2);
             y = getRowHeightSetting(row);
-            buttonList.add(new ButtonSlider(x, y, 100, 20, DungeonMapManager.getMapZoom(), 0.5F, 5F, 0.1F, new ButtonSlider.OnSliderChangeCallback() {
+            buttonList.add(new ButtonSlider(x, y, 100, 20, DungeonMapManager.getDenormalizedMapZoom(), DungeonMapManager.MIN_ZOOM, DungeonMapManager.MAX_ZOOM, 0.1F, new ButtonSlider.OnSliderChangeCallback() {
                 @Override
                 public void sliderUpdated(float value) {
                     DungeonMapManager.setMapZoom(value);


### PR DESCRIPTION
Map zoom setting simply didn't function as it was normalized twice on saving.
I'm not sure why we need to save a normalized value as it would be much easier to denormalize it once when changing the slider and handling a normal value from that point. but I kept it that way to not mess with peoples existing settings.