### PR TITLE
Added The End to zealot colouring

### DIFF
--- a/src/main/java/codes/biscuit/skyblockaddons/asm/hooks/ModelEndermanHook.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/asm/hooks/ModelEndermanHook.java
@@ -10,7 +10,7 @@ public class ModelEndermanHook {
     public static void setEndermanColor() {
         SkyblockAddons main = SkyblockAddons.getInstance();
         Location location = main.getUtils().getLocation();
-        if (main.getUtils().isOnSkyblock() && (location == Location.DRAGONS_NEST || location == Location.ZEALOT_BRUISER_HIDEOUT || location == Location.VOID_SLATE) && main.getConfigValues().isEnabled(Feature.CHANGE_ZEALOT_COLOR)) {
+        if (main.getUtils().isOnSkyblock() && (location == Location.DRAGONS_NEST || location == Location.ZEALOT_BRUISER_HIDEOUT || location == Location.THE_END || location == Location.VOID_SLATE) && main.getConfigValues().isEnabled(Feature.CHANGE_ZEALOT_COLOR)) {
             int color = main.getConfigValues().getColor(Feature.CHANGE_ZEALOT_COLOR);
             ColorUtils.bindColor(color);
         }


### PR DESCRIPTION
Part of the bruiser hideout is technically in "The End" and not "Zealot Bruiser Hideout". This commit fixes zealots flicking from default to recoloured while you run around the bruiser hideut.