### PR TITLE
Fix multiple username transformation

### DIFF
--- a/src/main/java/codes/biscuit/skyblockaddons/listeners/PlayerListener.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/listeners/PlayerListener.java
@@ -511,7 +511,7 @@ public class PlayerListener {
                 if(!suffix.equals(" ")) {
                     String finalSuffix = suffix;
                     String finalUsername = username;
-                    TextUtils.recursiveTransformAnyChatComponent(oldMessage, component -> {
+                    TextUtils.transformAnyChatComponent(oldMessage, component -> {
                                 if (component instanceof ChatComponentText & ((ChatComponentText)component).text.contains(finalUsername)) {
                                     ChatComponentText textComponent = (ChatComponentText) component;
                                     textComponent.text = textComponent.text.replace(finalUsername, finalUsername + finalSuffix);

--- a/src/main/java/codes/biscuit/skyblockaddons/listeners/PlayerListener.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/listeners/PlayerListener.java
@@ -511,11 +511,13 @@ public class PlayerListener {
                 if(!suffix.equals(" ")) {
                     String finalSuffix = suffix;
                     String finalUsername = username;
-                    TextUtils.recursiveTransformChatComponent(oldMessage, component -> {
+                    TextUtils.recursiveTransformAnyChatComponent(oldMessage, component -> {
                                 if (component instanceof ChatComponentText & ((ChatComponentText)component).text.contains(finalUsername)) {
                                     ChatComponentText textComponent = (ChatComponentText) component;
                                     textComponent.text = textComponent.text.replace(finalUsername, finalUsername + finalSuffix);
+                                    return true;
                                 }
+                                return false;
                             }
                     );
                 }

--- a/src/main/java/codes/biscuit/skyblockaddons/utils/TextUtils.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/utils/TextUtils.java
@@ -9,6 +9,7 @@ import java.text.NumberFormat;
 import java.text.ParseException;
 import java.util.*;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -453,10 +454,20 @@ public class TextUtils {
      * @param action action to be performed
      * @author Sychic
      */
-    public static void recursiveTransformChatComponent(IChatComponent chatComponent, Consumer<IChatComponent> action) {
+    public static void recursiveTransformAllChatComponents(IChatComponent chatComponent, Consumer<IChatComponent> action) {
         action.accept(chatComponent);
         for (IChatComponent sibling : chatComponent.getSiblings()) {
-            recursiveTransformChatComponent(sibling, action);
+            recursiveTransformAllChatComponents(sibling, action);
         }
+    }
+
+    public static boolean recursiveTransformAnyChatComponent(IChatComponent chatComponent, Predicate<IChatComponent> action) {
+        if(action.test(chatComponent))
+            return true;
+        for (IChatComponent sibling : chatComponent.getSiblings()) {
+            if(recursiveTransformAnyChatComponent(sibling, action))
+                return true;
+        }
+        return false;
     }
 }

--- a/src/main/java/codes/biscuit/skyblockaddons/utils/TextUtils.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/utils/TextUtils.java
@@ -454,18 +454,18 @@ public class TextUtils {
      * @param action action to be performed
      * @author Sychic
      */
-    public static void recursiveTransformAllChatComponents(IChatComponent chatComponent, Consumer<IChatComponent> action) {
+    public static void transformAllChatComponents(IChatComponent chatComponent, Consumer<IChatComponent> action) {
         action.accept(chatComponent);
         for (IChatComponent sibling : chatComponent.getSiblings()) {
-            recursiveTransformAllChatComponents(sibling, action);
+            transformAllChatComponents(sibling, action);
         }
     }
 
-    public static boolean recursiveTransformAnyChatComponent(IChatComponent chatComponent, Predicate<IChatComponent> action) {
+    public static boolean transformAnyChatComponent(IChatComponent chatComponent, Predicate<IChatComponent> action) {
         if(action.test(chatComponent))
             return true;
         for (IChatComponent sibling : chatComponent.getSiblings()) {
-            if(recursiveTransformAnyChatComponent(sibling, action))
+            if(transformAnyChatComponent(sibling, action))
                 return true;
         }
         return false;

--- a/src/main/java/codes/biscuit/skyblockaddons/utils/TextUtils.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/utils/TextUtils.java
@@ -461,6 +461,14 @@ public class TextUtils {
         }
     }
 
+    /**
+     * Recursively searches for a chat component to transform based on a given Predicate.
+     *
+     * Important to note that this function will stop on the first successful transformation, unlike {@link #transformAllChatComponents(IChatComponent, Consumer)}
+     * @param chatComponent root chat component
+     * @param action predicate that transforms a component and reports a successful transformation
+     * @return Whether any transformation occurred
+     */
     public static boolean transformAnyChatComponent(IChatComponent chatComponent, Predicate<IChatComponent> action) {
         if(action.test(chatComponent))
             return true;


### PR DESCRIPTION
Multiple transformation caused players mentioning themselves to allow the feature to transform the message body and break formatting.