### PR TITLE
New Feature : Ignore Skyblock Scoreboard based detection

### DIFF
--- a/src/main/java/codes/biscuit/skyblockaddons/core/Feature.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/core/Feature.java
@@ -237,7 +237,10 @@ public enum Feature {
     CHROMA_SIZE(-1, "settings.chromaSize", null, false),
     CHROMA_SATURATION(-1, "settings.chromaSaturation", null, false),
     CHROMA_BRIGHTNESS(-1, "settings.chromaBrightness", null, false),
-    TURN_ALL_FEATURES_CHROMA(-1, "settings.turnAllFeaturesChroma", null, false);
+    TURN_ALL_FEATURES_CHROMA(-1, "settings.turnAllFeaturesChroma", null, false),
+
+    IGNORE_SKYBLOCK_DETECTION(221, "settings.ignoreSkyblockDetection", true);
+
 
 
     /**
@@ -283,7 +286,7 @@ public enum Feature {
      */
     @Getter
     private static final Set<Feature> generalTabFeatures = new LinkedHashSet<>(Arrays.asList(TEXT_STYLE, WARNING_TIME, CHROMA_SPEED, CHROMA_MODE,
-            CHROMA_SIZE, TURN_ALL_FEATURES_CHROMA, CHROMA_SATURATION, CHROMA_BRIGHTNESS, USE_NEW_CHROMA_EFFECT, DEVELOPER_MODE));
+            CHROMA_SIZE, TURN_ALL_FEATURES_CHROMA, CHROMA_SATURATION, CHROMA_BRIGHTNESS, USE_NEW_CHROMA_EFFECT, DEVELOPER_MODE, IGNORE_SKYBLOCK_DETECTION));
 
     private static final int ID_AT_PREVIOUS_UPDATE = 199;
 

--- a/src/main/java/codes/biscuit/skyblockaddons/utils/EnumUtils.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/utils/EnumUtils.java
@@ -294,7 +294,8 @@ public class EnumUtils {
         TIMOLOB("TimoLob", "github.com/TimoLob", Feature.BROOD_MOTHER_ALERT),
         NOPOTHEGAMER("NopoTheGamer", "twitch.tv/nopothegamer", Feature.BAL_BOSS_ALERT),
         CATFACE("CatFace","github.com/CattoFace",Feature.PLAYER_SYMBOLS_IN_CHAT),
-        HANNIBAL2("Hannibal2", "github.com/hannibal00212", Feature.CRIMSON_ARMOR_ABILITY_STACKS, Feature.HIDE_TRUE_DEFENSE);
+        HANNIBAL2("Hannibal2", "github.com/hannibal00212", Feature.CRIMSON_ARMOR_ABILITY_STACKS, Feature.HIDE_TRUE_DEFENSE),
+        MIRROR_MARU("MirrorMaru", "https://github.com/MirrorMaru", Feature.IGNORE_SKYBLOCK_DETECTION);
 
         private final Set<Feature> features;
         private final String author;

--- a/src/main/java/codes/biscuit/skyblockaddons/utils/Utils.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/utils/Utils.java
@@ -253,11 +253,16 @@ public class Utils {
 
             // Check title for skyblock
             String strippedScoreboardTitle = ScoreboardManager.getStrippedScoreboardTitle();
-            for (String skyblock : SKYBLOCK_IN_ALL_LANGUAGES) {
-                if (strippedScoreboardTitle.startsWith(skyblock)) {
-                    foundSkyblockTitle = true;
-                    break;
+            if (main.getConfigValues().isDisabled(Feature.IGNORE_SKYBLOCK_DETECTION)) {
+                for (String skyblock : SKYBLOCK_IN_ALL_LANGUAGES) {
+                    if (strippedScoreboardTitle.startsWith(skyblock)) {
+                        foundSkyblockTitle = true;
+                        break;
+                    }
                 }
+            }
+            else {
+                foundSkyblockTitle = true;
             }
 
             if (foundSkyblockTitle) {

--- a/src/main/resources/lang/ar_SA.json
+++ b/src/main/resources/lang/ar_SA.json
@@ -178,6 +178,7 @@
     "chromaSaturation": "Chroma Saturation",
     "chromaBrightness": "Chroma Brightness",
     "useNewChromaEffect": "Use New Chroma Effect",
+    "ignoreSkyblockDetection" : "Ignore Skyblock ScoreBoard based detection",
     "showExperimentationTableTooltips": "Show Experimentation Table Tooltips",
     "drillFuelBar": "Drill Fuel Bar",
     "drillFuelNumber": "Drill Fuel Number",

--- a/src/main/resources/lang/bc_BC.json
+++ b/src/main/resources/lang/bc_BC.json
@@ -178,6 +178,7 @@
     "chromaSaturation": "Chroma Saturation",
     "chromaBrightness": "Chroma Brightness",
     "useNewChromaEffect": "Use New Chroma Effect",
+    "ignoreSkyblockDetection" : "Ignore Skyblock ScoreBoard based detection",
     "showExperimentationTableTooltips": "Show Experimentation Table Tooltips",
     "drillFuelBar": "Drill Fuel Bar",
     "drillFuelNumber": "Drill Fuel Number",

--- a/src/main/resources/lang/bg_BG.json
+++ b/src/main/resources/lang/bg_BG.json
@@ -178,6 +178,7 @@
     "chromaSaturation": "Наситеността на Chroma",
     "chromaBrightness": "Яркостта на Chroma",
     "useNewChromaEffect": "Използване на новата Chroma ефект",
+    "ignoreSkyblockDetection" : "Ignore Skyblock ScoreBoard based detection",
     "showExperimentationTableTooltips": "Покажи подсказки в Experimentation Table",
     "drillFuelBar": "Drill лента за гориво",
     "drillFuelNumber": "Количество гориво в Drill",

--- a/src/main/resources/lang/cs_CZ.json
+++ b/src/main/resources/lang/cs_CZ.json
@@ -178,6 +178,7 @@
     "chromaSaturation": "Chroma Saturation",
     "chromaBrightness": "Chroma Brightness",
     "useNewChromaEffect": "Use New Chroma Effect",
+    "ignoreSkyblockDetection" : "Ignore Skyblock ScoreBoard based detection",
     "showExperimentationTableTooltips": "Show Experimentation Table Tooltips",
     "drillFuelBar": "Drill Fuel Bar",
     "drillFuelNumber": "Drill Fuel Number",

--- a/src/main/resources/lang/da_DK.json
+++ b/src/main/resources/lang/da_DK.json
@@ -178,6 +178,7 @@
     "chromaSaturation": "Chroma Saturation",
     "chromaBrightness": "Chroma Brightness",
     "useNewChromaEffect": "Use New Chroma Effect",
+    "ignoreSkyblockDetection" : "Ignore Skyblock ScoreBoard based detection",
     "showExperimentationTableTooltips": "Show Experimentation Table Tooltips",
     "drillFuelBar": "Drill Fuel Bar",
     "drillFuelNumber": "Drill Fuel Number",

--- a/src/main/resources/lang/de_DE.json
+++ b/src/main/resources/lang/de_DE.json
@@ -178,6 +178,7 @@
     "chromaSaturation": "Chroma-Sättigung",
     "chromaBrightness": "Chroma-Helligkeit",
     "useNewChromaEffect": "Nutze den neuen Chroma-Effekt",
+    "ignoreSkyblockDetection" : "Ignore Skyblock ScoreBoard based detection",
     "showExperimentationTableTooltips": "Zeige Tooltips zum Experimentiertisch",
     "drillFuelBar": "Bohrtreibstoffleiste",
     "drillFuelNumber": "Bohrer Treibstoff Nummer",

--- a/src/main/resources/lang/el_GR.json
+++ b/src/main/resources/lang/el_GR.json
@@ -178,6 +178,7 @@
     "chromaSaturation": "Κορεσμός χρώματος",
     "chromaBrightness": "Φωτεινότητα Chroma",
     "useNewChromaEffect": "Χρησιμοποιήστε το νέο εφέ Χρωματισμού",
+    "ignoreSkyblockDetection" : "Ignore Skyblock ScoreBoard based detection",
     "showExperimentationTableTooltips": "Εμφάνιση συμβουλών εργαλείου πίνακα πειραματισμού",
     "drillFuelBar": "Δράπανο Fuel Bar",
     "drillFuelNumber": "Αριθμός καυσίμου τρυπανιών",

--- a/src/main/resources/lang/en_PT.json
+++ b/src/main/resources/lang/en_PT.json
@@ -178,6 +178,7 @@
     "chromaSaturation": "Chroma Col'rfullness",
     "chromaBrightness": "Level o' Chroma Brightness",
     "useNewChromaEffect": "Use Th' Effect o' New Chroma",
+    "ignoreSkyblockDetection" : "Ignore Skyblock ScoreBoard based detection",
     "showExperimentationTableTooltips": "Show Tooltips o' th' Experimentation Table",
     "drillFuelBar": "Drill Fuel Bar",
     "drillFuelNumber": "Drill Fuel Number",

--- a/src/main/resources/lang/en_US.json
+++ b/src/main/resources/lang/en_US.json
@@ -178,6 +178,7 @@
     "chromaSaturation": "Chroma Saturation",
     "chromaBrightness": "Chroma Brightness",
     "useNewChromaEffect": "Use New Chroma Effect",
+    "ignoreSkyblockDetection" : "Ignore Skyblock ScoreBoard based detection",
     "showExperimentationTableTooltips": "Show Experimentation Table Tooltips",
     "drillFuelBar": "Drill Fuel Bar",
     "drillFuelNumber": "Drill Fuel Number",

--- a/src/main/resources/lang/es_ES.json
+++ b/src/main/resources/lang/es_ES.json
@@ -178,6 +178,7 @@
     "chromaSaturation": "Saturación del Croma",
     "chromaBrightness": "Brillo del Croma",
     "useNewChromaEffect": "Usar el Nuevo Efecto Croma",
+    "ignoreSkyblockDetection" : "Ignore Skyblock ScoreBoard based detection",
     "showExperimentationTableTooltips": "Mostrar Información de Objeto en la Experimentation Table",
     "drillFuelBar": "Barra de Drill Fuel",
     "drillFuelNumber": "Número de Drill Fuel",

--- a/src/main/resources/lang/es_MX.json
+++ b/src/main/resources/lang/es_MX.json
@@ -178,6 +178,7 @@
     "chromaSaturation": "Saturación del Croma",
     "chromaBrightness": "Brillo del Croma",
     "useNewChromaEffect": "Usar Nuevo Efecto Croma",
+    "ignoreSkyblockDetection" : "Ignore Skyblock ScoreBoard based detection",
     "showExperimentationTableTooltips": "Mostrar Información de Objeto en la Experimentation Table",
     "drillFuelBar": "Barra de Drill Fuel",
     "drillFuelNumber": "Número de Drill Fuel",

--- a/src/main/resources/lang/et_EE.json
+++ b/src/main/resources/lang/et_EE.json
@@ -178,6 +178,7 @@
     "chromaSaturation": "Chroma Saturation",
     "chromaBrightness": "Chroma Brightness",
     "useNewChromaEffect": "Use New Chroma Effect",
+    "ignoreSkyblockDetection" : "Ignore Skyblock ScoreBoard based detection",
     "showExperimentationTableTooltips": "Show Experimentation Table Tooltips",
     "drillFuelBar": "Drill Fuel Bar",
     "drillFuelNumber": "Drill Fuel Number",

--- a/src/main/resources/lang/fa_IR.json
+++ b/src/main/resources/lang/fa_IR.json
@@ -178,6 +178,7 @@
     "chromaSaturation": "Chroma Saturation",
     "chromaBrightness": "Chroma Brightness",
     "useNewChromaEffect": "Use New Chroma Effect",
+    "ignoreSkyblockDetection" : "Ignore Skyblock ScoreBoard based detection",
     "showExperimentationTableTooltips": "Show Experimentation Table Tooltips",
     "drillFuelBar": "Drill Fuel Bar",
     "drillFuelNumber": "Drill Fuel Number",

--- a/src/main/resources/lang/fi_FI.json
+++ b/src/main/resources/lang/fi_FI.json
@@ -178,6 +178,7 @@
     "chromaSaturation": "Väriefektin kylläisyys",
     "chromaBrightness": "Väriefektin kirkkaus",
     "useNewChromaEffect": "Käytä uutta väriefektiä",
+    "ignoreSkyblockDetection" : "Ignore Skyblock ScoreBoard based detection",
     "showExperimentationTableTooltips": "Näytä Experimentation-pöydän esineiden tiedot",
     "drillFuelBar": "Poran polttoainetankki",
     "drillFuelNumber": "Poran polttoainearvo",

--- a/src/main/resources/lang/fr_FR.json
+++ b/src/main/resources/lang/fr_FR.json
@@ -178,6 +178,7 @@
     "chromaSaturation": "Saturation Chroma",
     "chromaBrightness": "Luminosité Chroma",
     "useNewChromaEffect": "Utiliser le nouveau effet Chroma",
+    "ignoreSkyblockDetection" : "Ignorer la détection Skyblock via le ScoreBoard",
     "showExperimentationTableTooltips": "Afficher l'aide pour l'Experimentation Table",
     "drillFuelBar": "Barre de carburant du Drill",
     "drillFuelNumber": "Quantité de carburant du Drill",

--- a/src/main/resources/lang/he_IL.json
+++ b/src/main/resources/lang/he_IL.json
@@ -178,6 +178,7 @@
     "chromaSaturation": "רווית הChroma",
     "chromaBrightness": "עוצמת הבהירות של הChroma",
     "useNewChromaEffect": "השתמש באפקט הChroma החדש",
+    "ignoreSkyblockDetection" : "Ignore Skyblock ScoreBoard based detection",
     "showExperimentationTableTooltips": "הצג כלי עזר בExperimentation Table",
     "drillFuelBar": "בר דלק המקדח",
     "drillFuelNumber": "כמות דלק מקדחה",

--- a/src/main/resources/lang/hi_IN.json
+++ b/src/main/resources/lang/hi_IN.json
@@ -178,6 +178,7 @@
     "chromaSaturation": "Chroma Saturation",
     "chromaBrightness": "Chroma Brightness",
     "useNewChromaEffect": "Use New Chroma Effect",
+    "ignoreSkyblockDetection" : "Ignore Skyblock ScoreBoard based detection",
     "showExperimentationTableTooltips": "Show Experimentation Table Tooltips",
     "drillFuelBar": "Drill Fuel Bar",
     "drillFuelNumber": "Drill Fuel Number",

--- a/src/main/resources/lang/hr_HR.json
+++ b/src/main/resources/lang/hr_HR.json
@@ -178,6 +178,7 @@
     "chromaSaturation": "Zasićenost kroma",
     "chromaBrightness": "Svjetloća krome",
     "useNewChromaEffect": "Koristite novi Chroma Effect",
+    "ignoreSkyblockDetection" : "Ignore Skyblock ScoreBoard based detection",
     "showExperimentationTableTooltips": "Pokaži savjete o tablicama za eksperimentiranje",
     "drillFuelBar": "Razina goriva bušilice",
     "drillFuelNumber": "Razina goriva bušilice",

--- a/src/main/resources/lang/hu_HU.json
+++ b/src/main/resources/lang/hu_HU.json
@@ -178,6 +178,7 @@
     "chromaSaturation": "Színátmenet telítettség",
     "chromaBrightness": "Színátmente világosság",
     "useNewChromaEffect": "Új színátmenet hatás használata",
+    "ignoreSkyblockDetection" : "Ignore Skyblock ScoreBoard based detection",
     "showExperimentationTableTooltips": "Experimentation Table Tooltip Mutató",
     "drillFuelBar": "Drill üzemanyag jelző",
     "drillFuelNumber": "Drill üzemanyag szám",

--- a/src/main/resources/lang/id_ID.json
+++ b/src/main/resources/lang/id_ID.json
@@ -178,6 +178,7 @@
     "chromaSaturation": "Saturasi Kroma",
     "chromaBrightness": "Kecerahan Kroma",
     "useNewChromaEffect": "Pakai Efek Kroma Baru",
+    "ignoreSkyblockDetection" : "Ignore Skyblock ScoreBoard based detection",
     "showExperimentationTableTooltips": "Perlihatkan Tooltips Experimentation Table",
     "drillFuelBar": "Bar Bahan Bakar Drill",
     "drillFuelNumber": "Jumlah Bahan Bakar Drill",

--- a/src/main/resources/lang/it_IT.json
+++ b/src/main/resources/lang/it_IT.json
@@ -178,6 +178,7 @@
     "chromaSaturation": "Saturazione Chroma",
     "chromaBrightness": "Luminosità Chroma",
     "useNewChromaEffect": "Usa un nuovo effetto Chroma",
+    "ignoreSkyblockDetection" : "Ignore Skyblock ScoreBoard based detection",
     "showExperimentationTableTooltips": "Mostra descrizioni dell'Experimentation Table",
     "drillFuelBar": "Barra di combustibile Drill",
     "drillFuelNumber": "Numero di combustibile Drill",

--- a/src/main/resources/lang/ja_JP.json
+++ b/src/main/resources/lang/ja_JP.json
@@ -178,6 +178,7 @@
     "chromaSaturation": "色変化の彩度",
     "chromaBrightness": "色変化の明度",
     "useNewChromaEffect": "新しい色変化の効果を使用",
+    "ignoreSkyblockDetection" : "Ignore Skyblock ScoreBoard based detection",
     "showExperimentationTableTooltips": "Experimentation Tableでアイテム説明文を表示",
     "drillFuelBar": "Drill Fuelゲージ",
     "drillFuelNumber": "Drill Fuel数",

--- a/src/main/resources/lang/ko_KR.json
+++ b/src/main/resources/lang/ko_KR.json
@@ -178,6 +178,7 @@
     "chromaSaturation": "무지개 채도",
     "chromaBrightness": "무지개 밝기",
     "useNewChromaEffect": "새로운 무지개 이펙트 사용하기",
+    "ignoreSkyblockDetection" : "Ignore Skyblock ScoreBoard based detection",
     "showExperimentationTableTooltips": "Experimentation Table 툴팁 보이기",
     "drillFuelBar": "Drill 연료 바",
     "drillFuelNumber": "Drill 연료 숫자",

--- a/src/main/resources/lang/lol_US.json
+++ b/src/main/resources/lang/lol_US.json
@@ -178,6 +178,7 @@
     "chromaSaturation": "Chroma Saturashun",
     "chromaBrightness": "Chroma Brightnes",
     "useNewChromaEffect": "Use New Chroma Effect",
+    "ignoreSkyblockDetection" : "Ignore Skyblock ScoreBoard based detection",
     "showExperimentationTableTooltips": "Show Experimentashun Table Tooltips",
     "drillFuelBar": "Drill Fuel Bar",
     "drillFuelNumber": "Drill Fuel Numbr",

--- a/src/main/resources/lang/lt_LT.json
+++ b/src/main/resources/lang/lt_LT.json
@@ -178,6 +178,7 @@
     "chromaSaturation": "Chroma Saturation",
     "chromaBrightness": "Chroma Brightness",
     "useNewChromaEffect": "Use New Chroma Effect",
+    "ignoreSkyblockDetection" : "Ignore Skyblock ScoreBoard based detection",
     "showExperimentationTableTooltips": "Show Experimentation Table Tooltips",
     "drillFuelBar": "Drill Fuel Bar",
     "drillFuelNumber": "Drill Fuel Number",

--- a/src/main/resources/lang/ms_MY.json
+++ b/src/main/resources/lang/ms_MY.json
@@ -178,6 +178,7 @@
     "chromaSaturation": "Chroma Saturation",
     "chromaBrightness": "Chroma Brightness",
     "useNewChromaEffect": "Use New Chroma Effect",
+    "ignoreSkyblockDetection" : "Ignore Skyblock ScoreBoard based detection",
     "showExperimentationTableTooltips": "Show Experimentation Table Tooltips",
     "drillFuelBar": "Drill Fuel Bar",
     "drillFuelNumber": "Drill Fuel Number",

--- a/src/main/resources/lang/nl_NL.json
+++ b/src/main/resources/lang/nl_NL.json
@@ -178,6 +178,7 @@
     "chromaSaturation": "Chromaverzadiging",
     "chromaBrightness": "Chromahelderheid",
     "useNewChromaEffect": "Nieuw Chroma-effect gebruiken",
+    "ignoreSkyblockDetection" : "Ignore Skyblock ScoreBoard based detection",
     "showExperimentationTableTooltips": "Experimentation Table-tooltips weergeven",
     "drillFuelBar": "Drill-brandstofbalk",
     "drillFuelNumber": "Drill-brandstofgetal",

--- a/src/main/resources/lang/no_NO.json
+++ b/src/main/resources/lang/no_NO.json
@@ -178,6 +178,7 @@
     "chromaSaturation": "Chroma Saturation",
     "chromaBrightness": "Chroma Brightness",
     "useNewChromaEffect": "Use New Chroma Effect",
+    "ignoreSkyblockDetection" : "Ignore Skyblock ScoreBoard based detection",
     "showExperimentationTableTooltips": "Show Experimentation Table Tooltips",
     "drillFuelBar": "Drill Fuel Bar",
     "drillFuelNumber": "Drill Fuel Number",

--- a/src/main/resources/lang/ow_Wo.json
+++ b/src/main/resources/lang/ow_Wo.json
@@ -178,6 +178,7 @@
     "chromaSaturation": "Chroma Saturation",
     "chromaBrightness": "Chroma Brightness",
     "useNewChromaEffect": "Use New Chroma Effect",
+    "ignoreSkyblockDetection" : "Ignore Skyblock ScoreBoard based detection",
     "showExperimentationTableTooltips": "Show Experimentation Table Tooltips",
     "drillFuelBar": "Drill Fuel Bar",
     "drillFuelNumber": "Drill Fuel Number",

--- a/src/main/resources/lang/pl_PL.json
+++ b/src/main/resources/lang/pl_PL.json
@@ -178,6 +178,7 @@
     "chromaSaturation": "Nasycenie koloru Chroma",
     "chromaBrightness": "Jasność koloru Chroma",
     "useNewChromaEffect": "Użyj nowego efektu Chroma",
+    "ignoreSkyblockDetection" : "Ignore Skyblock ScoreBoard based detection",
     "showExperimentationTableTooltips": "Pokaż dymki w Experimentation Table",
     "drillFuelBar": "Pasek paliwa wiertła",
     "drillFuelNumber": "Tekst paliwa wiertła",

--- a/src/main/resources/lang/pt_BR.json
+++ b/src/main/resources/lang/pt_BR.json
@@ -178,6 +178,7 @@
     "chromaSaturation": "Saturação do croma",
     "chromaBrightness": "Brilho do croma",
     "useNewChromaEffect": "Usar novo efeito croma",
+    "ignoreSkyblockDetection" : "Ignore Skyblock ScoreBoard based detection",
     "showExperimentationTableTooltips": "Mostrar descrições dos itens na Experimentation Table",
     "drillFuelBar": "Barra de combustível da Drill",
     "drillFuelNumber": "Número do combustível da Drill",

--- a/src/main/resources/lang/pt_PT.json
+++ b/src/main/resources/lang/pt_PT.json
@@ -178,6 +178,7 @@
     "chromaSaturation": "Saturação do croma",
     "chromaBrightness": "Brilho do croma",
     "useNewChromaEffect": "Usar o novo efeito croma",
+    "ignoreSkyblockDetection" : "Ignore Skyblock ScoreBoard based detection",
     "showExperimentationTableTooltips": "Mostrar descrições dos itens na Experimentation Table",
     "drillFuelBar": "Barra de combustível da Drill",
     "drillFuelNumber": "Número de combustível da Drill",

--- a/src/main/resources/lang/ro_RO.json
+++ b/src/main/resources/lang/ro_RO.json
@@ -178,6 +178,7 @@
     "chromaSaturation": "Chroma Saturation",
     "chromaBrightness": "Chroma Brightness",
     "useNewChromaEffect": "Use New Chroma Effect",
+    "ignoreSkyblockDetection" : "Ignore Skyblock ScoreBoard based detection",
     "showExperimentationTableTooltips": "Show Experimentation Table Tooltips",
     "drillFuelBar": "Drill Fuel Bar",
     "drillFuelNumber": "Drill Fuel Number",

--- a/src/main/resources/lang/ru_RU.json
+++ b/src/main/resources/lang/ru_RU.json
@@ -178,6 +178,7 @@
     "chromaSaturation": "Насыщенность Chroma",
     "chromaBrightness": "Яркость Chroma",
     "useNewChromaEffect": "Использовать новый эффект Chroma",
+    "ignoreSkyblockDetection" : "Ignore Skyblock ScoreBoard based detection",
     "showExperimentationTableTooltips": "Показывать описания предметов в Experimentation Table",
     "drillFuelBar": "Полоса топлива дрели",
     "drillFuelNumber": "Количество топлива в дрели",

--- a/src/main/resources/lang/sl_SI.json
+++ b/src/main/resources/lang/sl_SI.json
@@ -178,6 +178,7 @@
     "chromaSaturation": "Chroma Saturation",
     "chromaBrightness": "Chroma Brightness",
     "useNewChromaEffect": "Use New Chroma Effect",
+    "ignoreSkyblockDetection" : "Ignore Skyblock ScoreBoard based detection",
     "showExperimentationTableTooltips": "Show Experimentation Table Tooltips",
     "drillFuelBar": "Drill Fuel Bar",
     "drillFuelNumber": "Drill Fuel Number",

--- a/src/main/resources/lang/sr_CS.json
+++ b/src/main/resources/lang/sr_CS.json
@@ -178,6 +178,7 @@
     "chromaSaturation": "Chroma Saturation",
     "chromaBrightness": "Chroma Brightness",
     "useNewChromaEffect": "Use New Chroma Effect",
+    "ignoreSkyblockDetection" : "Ignore Skyblock ScoreBoard based detection",
     "showExperimentationTableTooltips": "Show Experimentation Table Tooltips",
     "drillFuelBar": "Drill Fuel Bar",
     "drillFuelNumber": "Drill Fuel Number",

--- a/src/main/resources/lang/sv_SE.json
+++ b/src/main/resources/lang/sv_SE.json
@@ -178,6 +178,7 @@
     "chromaSaturation": "Mättnad",
     "chromaBrightness": "Ljusstyrka",
     "useNewChromaEffect": "Use New Chroma Effect",
+    "ignoreSkyblockDetection" : "Ignore Skyblock ScoreBoard based detection",
     "showExperimentationTableTooltips": "Visa inforutor för experimentation table",
     "drillFuelBar": "Bränslemätare för drill",
     "drillFuelNumber": "Bränslenummer för drill",

--- a/src/main/resources/lang/th_TH.json
+++ b/src/main/resources/lang/th_TH.json
@@ -178,6 +178,7 @@
     "chromaSaturation": "Chroma Saturation",
     "chromaBrightness": "Chroma Brightness",
     "useNewChromaEffect": "Use New Chroma Effect",
+    "ignoreSkyblockDetection" : "Ignore Skyblock ScoreBoard based detection",
     "showExperimentationTableTooltips": "Show Experimentation Table Tooltips",
     "drillFuelBar": "Drill Fuel Bar",
     "drillFuelNumber": "Drill Fuel Number",

--- a/src/main/resources/lang/tr_TR.json
+++ b/src/main/resources/lang/tr_TR.json
@@ -178,6 +178,7 @@
     "chromaSaturation": "Chroma Doygunluğu",
     "chromaBrightness": "Chroma Parlaklığı",
     "useNewChromaEffect": "Yeni Chroma Efektini Kullan",
+    "ignoreSkyblockDetection" : "Ignore Skyblock ScoreBoard based detection",
     "showExperimentationTableTooltips": "Experimentation Table İpuçlarını Göster",
     "drillFuelBar": "Drill Yakıt Barı",
     "drillFuelNumber": "Drill Yakıt Sayısı",

--- a/src/main/resources/lang/uk_UA.json
+++ b/src/main/resources/lang/uk_UA.json
@@ -178,6 +178,7 @@
     "chromaSaturation": "Chroma Saturation",
     "chromaBrightness": "Chroma Brightness",
     "useNewChromaEffect": "Use New Chroma Effect",
+    "ignoreSkyblockDetection" : "Ignore Skyblock ScoreBoard based detection",
     "showExperimentationTableTooltips": "Show Experimentation Table Tooltips",
     "drillFuelBar": "Drill Fuel Bar",
     "drillFuelNumber": "Drill Fuel Number",

--- a/src/main/resources/lang/vi_VN.json
+++ b/src/main/resources/lang/vi_VN.json
@@ -178,6 +178,7 @@
     "chromaSaturation": "Độ nét sắc độ",
     "chromaBrightness": "Độ sáng sắc độ",
     "useNewChromaEffect": "Dùng hiệu ứng sắc độ mới",
+    "ignoreSkyblockDetection" : "Ignore Skyblock ScoreBoard based detection",
     "showExperimentationTableTooltips": "Hiện đáp án Experimentation Table",
     "drillFuelBar": "Thanh nguyên liệu của Drill",
     "drillFuelNumber": "Số nguyên liệu của Drill",

--- a/src/main/resources/lang/zh_CN.json
+++ b/src/main/resources/lang/zh_CN.json
@@ -178,6 +178,7 @@
     "chromaSaturation": "渐变色彩饱和度",
     "chromaBrightness": "渐变色彩亮度",
     "useNewChromaEffect": "使用新版渐变效果",
+    "ignoreSkyblockDetection" : "Ignore Skyblock ScoreBoard based detection",
     "showExperimentationTableTooltips": "启用 Experimentation Table 提示",
     "drillFuelBar": "Drill 燃料计量条",
     "drillFuelNumber": "Drill 燃料值",

--- a/src/main/resources/lang/zh_TW.json
+++ b/src/main/resources/lang/zh_TW.json
@@ -178,6 +178,7 @@
     "chromaSaturation": "漸變色飽和度",
     "chromaBrightness": "漸變色亮度",
     "useNewChromaEffect": "使用新版漸變效果",
+    "ignoreSkyblockDetection" : "Ignore Skyblock ScoreBoard based detection",
     "showExperimentationTableTooltips": "顯示 Experimentation Table 物品資訊",
     "drillFuelBar": "Drill 燃料計量條",
     "drillFuelNumber": "Drill 燃料值",


### PR DESCRIPTION
New Feature to ignore scoreboard based detection to prevent the mod to stop working when the scoreboard is changed.

Feature name in menu : Ignore Skyblock ScoreBoard based detection
