### PR TITLE
Update Minecraft wiki link to new domain

### DIFF
--- a/src/main/java/codes/biscuit/skyblockaddons/features/dungeonmap/MapMarker.java
+++ b/src/main/java/codes/biscuit/skyblockaddons/features/dungeonmap/MapMarker.java
@@ -15,7 +15,7 @@ public class MapMarker {
     private static final SkyblockAddons main = SkyblockAddons.getInstance();
     private static final Logger logger = SkyblockAddons.getLogger();
 
-    /** The icon type of this map marker (https://minecraft.fandom.com/wiki/Map#Map_icons) */
+    /** The icon type of this map marker (https://minecraft.wiki/w/Map#Map_icons) */
     private byte iconType;
     private float x;
     private float z;


### PR DESCRIPTION
The Minecraft Fandom wiki has been forked to a new domain: minecraft.wiki. Learn more here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates the old wiki link accordingly.